### PR TITLE
Fix request_forgery_protection to work with API requests.

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -1,7 +1,7 @@
 class ApplicationController < ActionController::Base
   # Prevent CSRF attacks by raising an exception.
   # For APIs, you may want to use :null_session instead.
-  protect_from_forgery with: :exception
+  protect_from_forgery :with => :null_session
 
   rescue_from MongoMapper::DocumentNotFound, :with => :error_404
 


### PR DESCRIPTION
The default settings raise an error if not given a valid
authenticity_token for all HTML and JSON requests.
