### PR TITLE
Change route delete requests to use query params.

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ This will return the corresponding route in JSON format.
 The following will create/update a route entry:
 
 ``` sh
-curl http://router-api.example.com/routes -v -X PUT \
+curl http://router-api.example.com/routes -X PUT \
     -H 'Content-type: application/json' \
     -d '{"route": {"incoming_path": "/foo", "route_type": "exact", "handler": "backend", "backend_id": "foo"}}'
 ```
@@ -34,9 +34,7 @@ On error a 400 status code will be returned, and the JSON response will include 
 ##### Deleting a route:
 
 ``` sh
-curl http://router-api.example.com/routes -v -X DELETE \
-    -H 'Content-type: application/json' \
-    -d '{"route": {"incoming_path": "/foo", "route_type": "exact"}}'
+curl http://router-api.example.com/routes?incoming_path=/foo&route_type=exact -X DELETE
 ```
 
 This will delete the corresponding route.  If no route matches the JSON request, a 400 status codce will be returned.
@@ -56,7 +54,7 @@ Will return the backend details in JSON format.
 ##### Creating/updating a backend:
 
 ``` sh
-curl http://router-api.example.com/backends/foo -v -X PUT \
+curl http://router-api.example.com/backends/foo -X PUT \
     -H 'Content-type: application/json' \
     -d '{"backend": {"backend_url": "http://foo.example.com/"}}'
 ```
@@ -68,7 +66,7 @@ On validation error a 400 status code will be returned, and the resulting JSON d
 ##### Deleting a backend:
 
 ``` sh
-curl http://router-api.example.com/backends/foo -v -X DELETE
+curl http://router-api.example.com/backends/foo -X DELETE
 ```
 
 This will delete the backend with id 'foo'.  This will only be allowed if the backend has no associated routes.  A 400 status code will be returned if this is the case.

--- a/app/controllers/routes_controller.rb
+++ b/app/controllers/routes_controller.rb
@@ -1,5 +1,5 @@
 class RoutesController < ApplicationController
-  before_filter :ensure_route_keys, :only => [:update, :destroy]
+  before_filter :ensure_route_keys, :only => [:update]
   after_filter :reload_routes_if_needed, :only => [:update, :destroy]
 
   def show
@@ -20,15 +20,10 @@ class RoutesController < ApplicationController
   end
 
   def destroy
-    route_details = params[:route]
-    @route = Route.find_by_incoming_path_and_route_type(route_details[:incoming_path], route_details[:route_type])
-    if @route
-      @route.destroy
-      @routes_need_reloading = true
-      render :json => @route
-    else
-      render :json => {"error" => "Route not found"}, :status => 400
-    end
+    @route = Route.find_by_incoming_path_and_route_type!(params[:incoming_path], params[:route_type])
+    @route.destroy
+    @routes_need_reloading = true
+    render :json => @route
   end
 
   private

--- a/spec/requests/routes_crud_spec.rb
+++ b/spec/requests/routes_crud_spec.rb
@@ -144,7 +144,7 @@ describe "managing routes" do
     end
 
     it "should delete the route" do
-      delete_json "/routes", :route => {:incoming_path => "/foo/bar", :route_type => "exact"}
+      delete "/routes", :incoming_path => "/foo/bar", :route_type => "exact"
 
       expect(response.code.to_i).to eq(200)
       expect(JSON.parse(response.body)).to eq({
@@ -160,22 +160,12 @@ describe "managing routes" do
       expect(router_reload_http_stub).to have_been_requested
     end
 
-    it "should return 400 for non-existent routes" do
-      delete_json "/routes", :route => {:incoming_path => "/foo/bar", :route_type => "prefix"}
-      expect(response.code.to_i).to eq(400)
+    it "should return 404 for non-existent routes" do
+      delete "/routes", :incoming_path => "/foo/bar", :route_type => "prefix"
+      expect(response.code.to_i).to eq(404)
 
-      delete_json "/routes", :route => {:incoming_path => "/foo", :route_type => "exact"}
-      expect(response.code.to_i).to eq(400)
-
-      expect(router_reload_http_stub).not_to have_been_requested
-    end
-
-    it "should not blow up if not given the necessary route lookup keys" do
-      delete_json "/routes", {}
-      expect(response.code.to_i).to eq(400)
-
-      delete "/routes"
-      expect(response.code.to_i).to eq(400)
+      delete "/routes", :incoming_path => "/foo", :route_type => "exact"
+      expect(response.code.to_i).to eq(404)
 
       expect(router_reload_http_stub).not_to have_been_requested
     end

--- a/spec/support/json_request_helper.rb
+++ b/spec/support/json_request_helper.rb
@@ -2,10 +2,6 @@ module JSONRequestHelper
   def put_json(path, attrs, headers = {})
     put path, attrs.to_json, {"Content-Type" => "application/json"}.merge(headers)
   end
-
-  def delete_json(path, attrs, headers = {})
-    delete path, attrs.to_json, {"Content-Type" => "application/json"}.merge(headers)
-  end
 end
 
 RSpec.configuration.include JSONRequestHelper, :type => :request


### PR DESCRIPTION
Makes it consistent with the GET endpoint, and will make the client implementation a little simpler.
