### PR TITLE
Tighten route incoming_path validation

### DIFF
--- a/app/models/route.rb
+++ b/app/models/route.rb
@@ -41,7 +41,7 @@ class Route
   def valid_incoming_path?
     return false unless self.incoming_path.starts_with?("/")
     uri = URI.parse(self.incoming_path)
-    uri.path == self.incoming_path
+    uri.path == self.incoming_path && self.incoming_path !~ %r{//} && self.incoming_path !~ %r{./\z}
   rescue URI::InvalidURIError
     false
   end

--- a/spec/models/route_spec.rb
+++ b/spec/models/route_spec.rb
@@ -57,6 +57,20 @@ describe Route do
           expect(@route).to have(1).error_on(:incoming_path)
         end
       end
+
+      it "should reject url paths with consecutive slashes or trailing slashes" do
+        [
+          "/foo//bar",
+          "/foo/bar///",
+          "//bar/baz",
+          "//",
+          "/foo/bar/",
+        ].each do |path|
+          @route.incoming_path = path
+          expect(@route).not_to be_valid
+          expect(@route).to have(1).error_on(:incoming_path)
+        end
+      end
     end
 
     describe "path uniqueness constraints" do


### PR DESCRIPTION
Reject paths with consecutive slashes, and with trailing slashes.  This will avoid creating routes that are unique, but not semantically unique.
