### PR TITLE
Add 'gone' route types.

### DIFF
--- a/app/models/route.rb
+++ b/app/models/route.rb
@@ -13,7 +13,7 @@ class Route
   validates :incoming_path, :uniqueness => {:scope => :route_type}
   validate :validate_incoming_path
   validates :route_type, :inclusion => {:in => %w(prefix exact)}
-  validates :handler, :inclusion => {:in => %w(backend redirect)}
+  validates :handler, :inclusion => {:in => %w(backend redirect gone)}
   with_options :if => :backend? do |be|
     be.validates :backend_id, :presence => true
     be.validate :validate_backend_id

--- a/spec/factories/routes.rb
+++ b/spec/factories/routes.rb
@@ -4,10 +4,11 @@ FactoryGirl.define do
   factory :route do
     route_type                "prefix"
     sequence(:incoming_path)  {|n| "/path/#{n}"}
-    handler                   "backend"
-    backend_id                { (Backend.first || create(:backend)).backend_id }
+    handler                   "gone"
 
     factory :backend_route do
+      handler       "backend"
+      backend_id    { (Backend.first || create(:backend)).backend_id }
     end
 
     factory :redirect_route do

--- a/spec/models/route_spec.rb
+++ b/spec/models/route_spec.rb
@@ -112,7 +112,7 @@ describe Route do
       end
 
       it "should only allow specific values" do
-        %w(backend redirect).each do |type|
+        %w(backend redirect gone).each do |type|
           @route.handler = type
           @route.valid?
           expect(@route).to have(0).errors_on(:handler)
@@ -148,6 +148,7 @@ describe Route do
         end
       end
     end
+
     context "with handler set to 'redirect'" do
       before :each do
         @route = FactoryGirl.build(:redirect_route)


### PR DESCRIPTION
These won't normally be created directly, but will be created when the
soft-delete functionality is implemented.
