### PR TITLE
Remove prefix root route

### DIFF
--- a/db/seeds/routes_from_varnish.rb
+++ b/db/seeds/routes_from_varnish.rb
@@ -40,8 +40,6 @@ backends.each do |backend|
 end
 
 routes = [
-  %w(/ prefix frontend),
-
   %w(/sitemap.xml exact search),
   %w(/sitemaps prefix search),
 
@@ -197,6 +195,7 @@ end
 # Remove some previously seeded routes.
 # This can be removed once it's run on prod.
 [
+  %w(/ prefix),
 ].each do |path, type|
   if route = Route.find_by_incoming_path_and_route_type(path, type)
     puts "Removing route #{path} (#{type}) => #{route.backend_id}"


### PR DESCRIPTION
This will allow the router to serve 404s for non-existent paths.  this has already been applied on production manually, this is just backporting the change here so the route doesn't get put back.

Also, cleaned up some deletions that are no longer needed (they've been run on prod)
