### PR TITLE
[Perf Plat] Remove Limelight routes

### DIFF
--- a/db/seeds/routes_from_varnish.rb
+++ b/db/seeds/routes_from_varnish.rb
@@ -13,8 +13,6 @@ backends = [
   'canary-frontend',
   'frontend',
   'licensify',
-  'limelight',
-  'publicapi',
   'spotlight',
   'tariff',
   'transactions-explorer',
@@ -32,9 +30,6 @@ routes = [
   %w(/apply-for-a-licence prefix licensify),
 
   %w(/trade-tariff prefix tariff),
-
-  %w(/performance/licensing prefix limelight),
-  %w(/performance/licensing/api prefix publicapi),
 
   %w(/performance/transactions-explorer prefix transactions-explorer),
 


### PR DESCRIPTION
These routes are now served by the regular `/performance` application, so we no longer need this exception.

I may need to remove these manually in production, not sure. I'll check when it's deployed.
