### PR TITLE
Re-add publicapi backend

### DIFF
--- a/db/seeds/routes_from_varnish.rb
+++ b/db/seeds/routes_from_varnish.rb
@@ -13,6 +13,7 @@ backends = [
   'canary-frontend',
   'frontend',
   'licensify',
+  'publicapi',
   'spotlight',
   'tariff',
   'transactions-explorer',


### PR DESCRIPTION
I removed this in edbf6029ddb728d59c5cbb0c1af0d4e08676c4cb because I assumed that it was only used by the Performance Platform.

`publicapi` is not just what the Performance Platform uses to proxy data requests, it's also used by lots of other apps on GOV.UK.

Sorry.
