### PR TITLE
Allow external or query string redirect targets

### DIFF
--- a/app/models/route.rb
+++ b/app/models/route.rb
@@ -75,8 +75,14 @@ class Route
 
   def validate_redirect_to
     return unless self.redirect_to.present? # This is to short circuit nil values
-    unless valid_redirect_target?(self.redirect_to)
-      errors[:redirect_to] << "is not a valid redirect target"
+    if self.route_type == 'exact'
+      unless valid_exact_redirect_target?(self.redirect_to)
+        errors[:redirect_to] << "is not a valid redirect target"
+      end
+    else
+      unless valid_local_path?(self.redirect_to)
+        errors[:redirect_to] << "is not a valid redirect target"
+      end
     end
   end
 
@@ -88,8 +94,9 @@ class Route
     false
   end
 
-  def valid_redirect_target?(target)
-    # Valid redirect targets differ from standard targets in that we allow:
+  def valid_exact_redirect_target?(target)
+    # Valid 'exact' redirect targets differ from standard targets in that we
+    # allow:
     # 1. External URLs, or
     # 2. Query strings
     uri = URI.parse(target)

--- a/spec/models/route_spec.rb
+++ b/spec/models/route_spec.rb
@@ -154,7 +154,7 @@ describe Route do
         @route = FactoryGirl.build(:redirect_route)
       end
 
-      describe "on redirect_to" do
+      describe "redirect_to field" do
         it "should be required" do
           @route.redirect_to = ""
           expect(@route).not_to be_valid
@@ -166,7 +166,15 @@ describe Route do
           expect(@route).not_to be_valid
           expect(@route).to have(1).error_on(:redirect_to)
         end
+      end
+    end
 
+    context "with handler set to 'redirect' and route_type set to 'exact'" do
+      before :each do
+        @route = FactoryGirl.build(:redirect_route, :route_type => 'exact')
+      end
+
+      describe "redirect_to field" do
         it "should allow query strings" do
           @route.redirect_to = "/foo/bar?thing"
           expect(@route).to be_valid


### PR DESCRIPTION
For `exact` routes that are of type `redirect` we want to support targets that:
- are query strings; or
- are external URLs

This widens the validation on `exact` redirects to allow the above, and is the API side of alphagov/router#78.

I'll remove the external URL seeds in a separate PR as they need to be coordinated with a deployment and some data migrations.
