### PR TITLE
Remove stray mongo_mapper reference.

### DIFF
--- a/config/initializers/generator_defaults.rb
+++ b/config/initializers/generator_defaults.rb
@@ -1,5 +1,4 @@
 Rails.application.config.generators do |g|
-  g.orm :mongo_mapper
   g.view_specs false
   g.helper false
   g.assets false


### PR DESCRIPTION
Left behind from before we switched back to Mongoid.