### PR TITLE
Replace index on incoming_path and route_type

### DIFF
--- a/app/models/route.rb
+++ b/app/models/route.rb
@@ -10,6 +10,10 @@ class Route
 
   index({:incoming_path => 1}, :unique => true)
 
+  # The router loads the routes in order, and therefore needs this index.
+  # This is to enable it to generate a consistent checksum of the routes.
+  index({:incoming_path => 1, :route_type => 1})
+
   HANDLERS = %w(backend redirect gone)
 
   validates :incoming_path, :uniqueness => true

--- a/db/migrate/20150113104959_cleanup_old_index.rb
+++ b/db/migrate/20150113104959_cleanup_old_index.rb
@@ -1,0 +1,10 @@
+class CleanupOldIndex < Mongoid::Migration
+  def self.up
+    # Remove existing index definition so it can be re-created according to the
+    # current definition (non-unique)
+    Route.collection.indexes.drop(:incoming_path => 1, :route_type => 1)
+  end
+
+  def self.down
+  end
+end


### PR DESCRIPTION
The router loads the routes in order, and therefore benefits from this index.

It's been necessary to add a migration to remove the existing (unique) index, otherwise Mongoid won't notice that it's different and re-create it according to the definition (Mongoid only looks at the fields in the index when comparing with existing ones).

Comparison of loading the routes with and without the index - Note the [`scanAndOrder` field](http://docs.mongodb.org/v2.4/reference/method/cursor.explain/#explain.scanAndOrder) in the following output as well as the difference in time (`millis`).

Without the index:
```
development:PRIMARY> db.routes.find().sort({incoming_path: 1, route_type: 1}).explain()
{
  "cursor" : "BasicCursor",
  "isMultiKey" : false,
  "n" : 26796,
  "nscannedObjects" : 26796,
  "nscanned" : 26796,
  "nscannedObjectsAllPlans" : 26796,
  "nscannedAllPlans" : 26796,
  "scanAndOrder" : true,
  "indexOnly" : false,
  "nYields" : 0,
  "nChunkSkips" : 0,
  "millis" : 134,
  "indexBounds" : {

  },
  "server" : "development:27017"
}
```

with the index:
```
development:PRIMARY> db.routes.find().sort({incoming_path: 1, route_type: 1}).explain()
{
  "cursor" : "BtreeCursor incoming_path_1_route_type_1",
  "isMultiKey" : false,
  "n" : 26796,
  "nscannedObjects" : 26796,
  "nscanned" : 26796,
  "nscannedObjectsAllPlans" : 26796,
  "nscannedAllPlans" : 26796,
  "scanAndOrder" : false,
  "indexOnly" : false,
  "nYields" : 0,
  "nChunkSkips" : 0,
  "millis" : 16,
  "indexBounds" : {
    "incoming_path" : [
      [
        {
          "$minElement" : 1
        },
        {
          "$maxElement" : 1
        }
      ]
    ],
    "route_type" : [
      [
        {
          "$minElement" : 1
        },
        {
          "$maxElement" : 1
        }
      ]
    ]
  },
  "server" : "development:27017"
}
```