### PR TITLE
Remove seeding of /performance routes.

### DIFF
--- a/db/seeds/routes_from_varnish.rb
+++ b/db/seeds/routes_from_varnish.rb
@@ -12,7 +12,6 @@ end
 backends = [
   'canary-frontend',
   'licensify',
-  'spotlight',
   'tariff',
   'transactions-explorer',
 ]
@@ -31,8 +30,6 @@ routes = [
   %w(/trade-tariff prefix tariff),
 
   %w(/performance/transactions-explorer prefix transactions-explorer),
-
-  %w(/performance prefix spotlight),
 
   %w(/__canary__ exact canary-frontend),
 ]

--- a/db/seeds/routes_from_varnish.rb
+++ b/db/seeds/routes_from_varnish.rb
@@ -13,7 +13,6 @@ backends = [
   'canary-frontend',
   'licensify',
   'tariff',
-  'transactions-explorer',
 ]
 
 backends.each do |backend|
@@ -28,8 +27,6 @@ routes = [
   %w(/apply-for-a-licence prefix licensify),
 
   %w(/trade-tariff prefix tariff),
-
-  %w(/performance/transactions-explorer prefix transactions-explorer),
 
   %w(/__canary__ exact canary-frontend),
 ]

--- a/db/seeds/routes_from_varnish.rb
+++ b/db/seeds/routes_from_varnish.rb
@@ -11,7 +11,6 @@ end
 
 backends = [
   'canary-frontend',
-  'frontend',
   'licensify',
   'spotlight',
   'tariff',
@@ -45,15 +44,4 @@ routes.each do |path, type, backend|
   route.handler = "backend"
   route.backend_id = backend
   route.save!
-end
-
-# Remove some previously seeded routes.
-# This can be removed once it's run on prod.
-[
-  %w(/ prefix),
-].each do |path, type|
-  if route = Route.where(:incoming_path => path, :route_type => type).first
-    puts "Removing route #{path} (#{type}) => #{route.backend_id}"
-    route.destroy
-  end
 end


### PR DESCRIPTION
This is now handled by the application itself at deploy time.

This also cleans up the removal of the `/` prefix route. This was left from when the router was originally put live, and we switched to using exact routes wherever we could.

**Added:**
Remove the `/performance/transactions-explorer` route seeding.  This has been retired, and is currently a redirect to `/performance`.