### PR TITLE
Support HTTPS backends

### DIFF
--- a/app/models/backend.rb
+++ b/app/models/backend.rb
@@ -28,7 +28,7 @@ class Backend
 
   def valid_backend_url?
     uri = URI.parse(self.backend_url)
-    uri.scheme == "http" &&
+    uri.scheme =~ /^https?$/ &&
       uri.host.present? &&
       uri.path.present? &&
       uri.query.blank? &&

--- a/spec/models/backend_spec.rb
+++ b/spec/models/backend_spec.rb
@@ -47,10 +47,9 @@ RSpec.describe Backend, :type => :model do
         expect(@backend).to be_valid
       end
 
-      it "should not accept an HTTPS URL" do
+      it "should accept an HTTPS URL" do
         @backend.backend_url = "https://foo.example.com/"
-        expect(@backend).not_to be_valid
-        expect(@backend.errors[:backend_url].size).to eq(1)
+        expect(@backend).to be_valid
       end
 
       it "should reject invalid URLs" do


### PR DESCRIPTION
Have the router-api consider backends using `https` as the URI scheme to
be valid URLs.

We're about to migrate most of the GOV.UK stack to a new provider, but
for accreditation reasons, Licensify will be continue to be hosted in
Skyscape.

Rather than reverse-proxy requests to the Licensify backend in Skyscape
further down the stack, have the router-api accept HTTPS URLs so that
the router can reverse-proxy requests to Licensify directly.

No changes to the router itself are necessary.

/cc @bradleywright @alext 