### PR TITLE
Remove the trade tariff prefix route registration.

### DIFF
--- a/db/seeds/routes_from_varnish.rb
+++ b/db/seeds/routes_from_varnish.rb
@@ -12,7 +12,6 @@ end
 backends = {
   'canary-frontend' => {'tls' => false},
   'licensify' => {'tls' => true},
-  'tariff' => {'tls' => false},
 }
 
 backends.each do |name, properties|
@@ -30,9 +29,6 @@ end
 
 routes = [
   %w(/apply-for-a-licence prefix licensify),
-
-  %w(/trade-tariff prefix tariff),
-
   %w(/__canary__ exact canary-frontend),
 ]
 


### PR DESCRIPTION
This is now handled via trade tariff frontend:
https://github.com/alphagov/trade-tariff-frontend/pull/189

https://trello.com/c/blLdEZN5/292-make-apps-register-special-routes-on-deploy