### PR TITLE
Temporarily disable seeding of Licensify route

### DIFF
--- a/db/seeds/routes_from_varnish.rb
+++ b/db/seeds/routes_from_varnish.rb
@@ -11,7 +11,10 @@ end
 
 backends = {
   'canary-frontend' => {'tls' => false},
-  'licensify' => {'tls' => true},
+# FIXME: Disabled to prevent router-api deployments from re-registering the
+# Licensify route in Carrenza Production.  To be removed once Licensify no
+# longer performs destructive actions when handling GET requests.
+#  'licensify' => {'tls' => true},
 }
 
 backends.each do |name, properties|
@@ -28,7 +31,10 @@ backends.each do |name, properties|
 end
 
 routes = [
-  %w(/apply-for-a-licence prefix licensify),
+# FIXME: Disabled to prevent router-api deployments from re-registering the
+# Licensify route in Carrenza Production.  To be removed once Licensify no
+# longer performs destructive actions when handling GET requests.
+#  %w(/apply-for-a-licence prefix licensify),
   %w(/__canary__ exact canary-frontend),
 ]
 


### PR DESCRIPTION
Don't seed a route or backend for the Licensify application.

This is a temporary change to prevent the Licensify route from being
re-registered in Carrenza Production, where we have disabled that route
until Licensify no longer performs destructive actions (i.e. database
writes) when handling GET requests.

This caused issues when we replayed GET requests against Carrenza
Production from Staging Production.

This workaround feels a bit hamfisted, however it's the simplest way to
ensure that Licensify is not accidentally re-enabled in Carrenza
Production. Seeding these particular routes is not strictly required as
once they're set, nothing should normally remove them, so it's safe to
remove them from here temporarily.

I'll add a step to the migration plan to ensure that the route is functional for when we migrate to Carrenza.

/cc @bradleywright 