### PR TITLE
Revert "Merge pull request #73 from alphagov/dont_seed_licensify"

### DIFF
--- a/db/seeds/routes_from_varnish.rb
+++ b/db/seeds/routes_from_varnish.rb
@@ -11,10 +11,7 @@ end
 
 backends = {
   'canary-frontend' => {'tls' => false},
-# FIXME: Disabled to prevent router-api deployments from re-registering the
-# Licensify route in Carrenza Production.  To be removed once Licensify no
-# longer performs destructive actions when handling GET requests.
-#  'licensify' => {'tls' => true},
+  'licensify' => {'tls' => true},
 }
 
 backends.each do |name, properties|
@@ -31,10 +28,7 @@ backends.each do |name, properties|
 end
 
 routes = [
-# FIXME: Disabled to prevent router-api deployments from re-registering the
-# Licensify route in Carrenza Production.  To be removed once Licensify no
-# longer performs destructive actions when handling GET requests.
-#  %w(/apply-for-a-licence prefix licensify),
+  %w(/apply-for-a-licence prefix licensify),
   %w(/__canary__ exact canary-frontend),
 ]
 


### PR DESCRIPTION
This reverts commit 139aeb0d7687ebe501697efb74810ae1cdbba115, reversing
changes made to b31ee47f8f0912e95f0c5ef8097d9f1dd9748d81.

A more persistent fix has been implemented in:
https://github.gds/gds/puppet/pull/3333