### PR TITLE
Add support for disabled flag on routes.

### DIFF
--- a/app/models/route.rb
+++ b/app/models/route.rb
@@ -4,6 +4,7 @@ class Route
   field :incoming_path, :type => String
   field :route_type, :type => String
   field :handler, :type => String
+  field :disabled, :type => Boolean, :default => false
   field :backend_id, :type => String
   field :redirect_to, :type => String
   field :redirect_type, :type => String


### PR DESCRIPTION
This is the companion to https://github.com/alphagov/router/pull/100
which implements this in the router itself.

A route that's flagged as disabled will cause the router to return a 503
for all matching requests.