### PR TITLE
Router reload now returns 202

### DIFF
--- a/lib/router_reloader.rb
+++ b/lib/router_reloader.rb
@@ -23,7 +23,7 @@ class RouterReloader
     @errors = []
     @urls.each do |url|
       response = Net::HTTP.post_form(URI.parse(url), {})
-      @errors << [url, response] unless response.code.to_i == 200
+      @errors << [url, response] unless response.code.to_s =~ /20[02]/
     end
     if @errors.any?
       Airbrake.notify_or_ignore(

--- a/spec/lib/router_reloader_spec.rb
+++ b/spec/lib/router_reloader_spec.rb
@@ -35,7 +35,7 @@ RSpec.describe RouterReloader do
 
     it "should POST to the reload endpoint on all the configured routers, and return true" do
       r1 = stub_request(:post, "http://foo.example.com:1234/reload").to_return(status: 200)
-      r2 = stub_request(:post, "http://bar.example.com:4321/reload").to_return(status: 200)
+      r2 = stub_request(:post, "http://bar.example.com:4321/reload").to_return(status: 202)
 
       expect(RouterReloader.reload).to be_truthy
 
@@ -59,7 +59,7 @@ RSpec.describe RouterReloader do
 
       it "should still reload subsequent hosts on error" do
         r1 = stub_request(:post, "http://foo.example.com:1234/reload").to_return(status: 401, body: "Authorisation required")
-        r2 = stub_request(:post, "http://bar.example.com:4321/reload").to_return(status: 200)
+        r2 = stub_request(:post, "http://bar.example.com:4321/reload").to_return(status: 202)
 
         RouterReloader.reload
 


### PR DESCRIPTION
The router’s reload endpoint is becoming asynchronous, so will soon
start returning 202 responses. This will accept these as a success
response.

