### PR TITLE
Ensure all travel advice is rendered by multipage-frontend...

### DIFF
--- a/db/migrate/20160421102740_update_travel_advice_backend_id.rb
+++ b/db/migrate/20160421102740_update_travel_advice_backend_id.rb
@@ -1,0 +1,18 @@
+class UpdateTravelAdviceBackendId < Mongoid::Migration
+  def self.up
+    Route.where(backend_id: "frontend", incoming_path: /^\/foreign-travel-advice\/[aA-zZ-]+$/).each do |route|
+      route.backend_id = "multipage-frontend"
+      route.save!
+      puts "Updated #{route.incoming_path} to backend_id: multipage-frontend"
+    end
+
+    if RouterReloader.reload
+      puts "Router reloaded"
+    else
+      puts "Failed to reload router"
+    end
+  end
+
+  def self.down
+  end
+end


### PR DESCRIPTION
https://trello.com/c/Xo8Bh7bh/2-serve-ta-publisher-from-multipage-front-end-for-all-countries

36 routes for travel advice countries still point to
[frontend](https://github.com/alphagov/frontend) where they should be directing requests to [multipage-frontend](https://github.com/alphagov/multipage-frontend), this PR migrates these routes as they relate to [travel advice which has not received any content updates since the switch to multipage-frontend](https://www.gov.uk/api/content/foreign-travel-advice/anguilla).