### PR TITLE
Add a rake task to modify backend_url

### DIFF
--- a/lib/tasks/backend.rake
+++ b/lib/tasks/backend.rake
@@ -1,0 +1,23 @@
+namespace :backend do
+  desc 'Updates backend_url for a given backend'
+  task :modify_url, [:backend_id, :backend_url] => [:environment] do |_t, args|
+    unless args[:backend_id] && args[:backend_url]
+      raise 'Requires backend_id and backend_url to be passed as parameters'
+    end
+
+    backend_id = args[:backend_id]
+    backend_url = args[:backend_url]
+
+    backend = Backend.where(backend_id: backend_id).first
+    old_url = backend.backend_url
+    backend.backend_url = backend_url
+
+    puts "Changing #{backend_id} from #{old_url} to #{backend_url}"
+
+    backend.save!
+
+    puts 'Reloading router'
+
+    RouterReloader.reload
+  end
+end


### PR DESCRIPTION
We need to modify backend_url in the router after the data sync happens from production to staging and integration.

Initially this is just for the tariff app which is migrating to the government PaaS, but eventually we should use this approach to update all our application hostnames (this behaviour is currently in env-sync-and-backup which makes queries directly against a `mongo` shell which is not where that should live).