### PR TITLE
[DO NOT MERGE] Fix race condition in RoutesController#update

### DIFF
--- a/app/controllers/routes_controller.rb
+++ b/app/controllers/routes_controller.rb
@@ -11,9 +11,13 @@ class RoutesController < ApplicationController
 
   def update
     route_details = @request_data[:route]
-    @route = Route.find_or_initialize_by(incoming_path: route_details.delete(:incoming_path))
-    status_code = @route.new_record? ? 201 : 200
-    @route.update_attributes(route_details) || status_code = 422
+    @route = Route.new(route_details)
+    if @route.valid?
+      new_route = @route.upsert_on_path(route_details)
+      status_code = new_route.incoming_path.nil? ? 201 : 200
+    else
+      status_code = 422
+    end
     render json: @route, status: status_code
   end
 

--- a/spec/controllers/routes_controller_spec.rb
+++ b/spec/controllers/routes_controller_spec.rb
@@ -1,0 +1,37 @@
+require 'rails_helper'
+require Rails.root.join('app/models/route')
+
+RSpec.describe RoutesController, type: :controller do
+  before do
+    FactoryGirl.create(:backend, backend_id: "a-backend")
+  end
+
+  let(:data) {
+    {
+      route: {
+        incoming_path: "/foo/bar", route_type: "prefix", handler: "backend", backend_id: "a-backend"
+      }
+    }.to_json
+  }
+
+  it "should not fail on multiple simultaneous requests" do
+    bypass_rescue
+    failed = false
+
+    threads = 4.times.map do
+      Thread.new do
+        #true while wait_for_it
+        begin
+          put :update, data
+        rescue Moped::Errors::OperationFailure
+          failed = true
+        rescue AbstractController::DoubleRenderError
+          # this error will happen if both threads succeed, so this is fine.
+        end
+      end
+    end
+    threads.each(&:join)
+
+    expect(failed).to be false
+  end
+end

--- a/spec/models/route_spec.rb
+++ b/spec/models/route_spec.rb
@@ -72,13 +72,6 @@ RSpec.describe Route, type: :model do
       end
 
       describe "uniqueness" do
-        it "is unique" do
-          FactoryGirl.create(:route, incoming_path: '/foo')
-          route.incoming_path = '/foo'
-          expect(route).not_to be_valid
-          expect(route.errors[:incoming_path].size).to eq(1)
-        end
-
         it "will have a db level uniqueness constraint" do
           FactoryGirl.create(:route, incoming_path: '/foo')
           route.incoming_path = '/foo'


### PR DESCRIPTION
It was possible for two simultaneous requests to attempt to create a
route at the same path; find_or_initialize_by would fail to find the
route in both cases, and one would then succeed in saving the new route
but the second would fail.

The solution is to make this atomic, but we can't use the basic upsert
method because our unique key is a separate id, not the incoming_path.
Instead, we use the underlying Mongo find_and_modify method with
upsert:true, which allows us to specify which fields to search on to
find a document to update.

However, this does not call model validation or callbacks. We need to
validate the data before doing the call; unfortunately, this means we
need to remove the Mongoid uniqueness validator, as otherwise updates
would always conflict at this point. We still have a unique constraint
in the db itself though.

We also need to run callbacks explicitly. Currently there is only one,
on after_create, so we run this if the find_and_modify caused a create
only (there is no way of telling this directly, but that call returns
the document *before* the update, so we can tell it's a create if that
document is blank).