### PR TITLE
Fix race condition in RoutesController#update, take 2

### DIFF
--- a/app/models/route.rb
+++ b/app/models/route.rb
@@ -17,6 +17,7 @@ class Route
   index({incoming_path: 1, route_type: 1})
 
   HANDLERS = %w(backend redirect gone)
+  DUPLICATE_KEY_ERROR = 11000
 
   validates :incoming_path, uniqueness: true
   validate :validate_incoming_path

--- a/spec/controllers/routes_controller_spec.rb
+++ b/spec/controllers/routes_controller_spec.rb
@@ -1,0 +1,36 @@
+require 'rails_helper'
+require Rails.root.join('app/models/route')
+
+RSpec.describe RoutesController, type: :controller do
+  before do
+    FactoryGirl.create(:backend, backend_id: "a-backend")
+  end
+
+  let(:data) {
+    {
+      route: {
+        incoming_path: "/foo/bar", route_type: "prefix", handler: "backend", backend_id: "a-backend"
+      }
+    }.to_json
+  }
+
+  it "should not fail on multiple simultaneous requests" do
+    bypass_rescue
+    failed = false
+
+    threads = 4.times.map do
+      Thread.new do
+        begin
+          put :update, data
+        rescue Moped::Errors::OperationFailure
+          failed = true
+        rescue AbstractController::DoubleRenderError
+          # this error will happen if both threads succeed, so this is fine.
+        end
+      end
+    end
+    threads.each(&:join)
+
+    expect(failed).to be false
+  end
+end


### PR DESCRIPTION
It was possible for two simultaneous requests to attempt to create a
route at the same path; find_or_initialize_by would fail to find the
route in both cases, and one would then succeed in saving the new route
but the second would fail.

The solution is to make this atomic, but we can't use the upsert
method because our unique key is a separate id, not the incoming_path.
Instead, we retry the update within the method a maximum of three
times.