### PR TITLE
Change default MongoDB uri to use ENV var

### DIFF
--- a/config/mongoid.yml
+++ b/config/mongoid.yml
@@ -1,7 +1,7 @@
 development:
   sessions:
     default:
-      uri: mongodb://localhost/router
+      uri: <%= ENV["MONGODB_URI"] || "mongodb://localhost/router" %>
       options:
         write:
           w: 1
@@ -15,7 +15,7 @@ development:
 test:
   sessions:
     default:
-      uri: mongodb://localhost/router_api_test
+      uri: <%= ENV["TEST_MONGODB_URI"] || "mongodb://localhost/router_api_test" %>
       options:
         write:
           w: 1
@@ -28,7 +28,7 @@ test:
 production:
   sessions:
     default:
-      uri: <%= ENV['MONGODB_URI'] %>
+      uri: <%= ENV["MONGODB_URI"] %>
       options:
         write:
           w: 1


### PR DESCRIPTION
Falls back to the defaults when ENV vars are not available. The TEST_*
prefix naming format is based on the TEST_DATABASE_URL one used in
Publishing API.