### PR TITLE
Upgrade all backends from HTTP to HTTPS

### DIFF
--- a/db/migrate/20161119142122_make_backends_https.rb
+++ b/db/migrate/20161119142122_make_backends_https.rb
@@ -1,0 +1,16 @@
+class MakeBackendsHttps < Mongoid::Migration
+  def self.up
+    Backend.all.each do |backend|
+      uri = URI.parse(backend.backend_url)
+
+      if uri.scheme == 'http'
+        uri.scheme = 'https'
+        backend.backend_url = uri.to_s
+        backend.save!
+      end
+    end
+  end
+
+  def self.down
+  end
+end

--- a/db/seeds/routes_from_varnish.rb
+++ b/db/seeds/routes_from_varnish.rb
@@ -9,18 +9,13 @@ unless ENV['GOVUK_APP_DOMAIN'].present?
   abort "GOVUK_APP_DOMAIN is not set.  Maybe you need to run under govuk_setenv..."
 end
 
-backends = {
-  'canary-frontend' => {'tls' => false},
-  'licensify' => {'tls' => true},
-}
+backends = %w(
+  canary-frontend
+  licensify
+)
 
-backends.each do |name, properties|
-  if properties['tls'] == true
-    protocol = 'https'
-  else
-    protocol = 'http'
-  end
-  url = "#{protocol}://#{name}.#{ENV['GOVUK_APP_DOMAIN']}/"
+backends.each do |name|
+  url = "https://#{name}.#{ENV['GOVUK_APP_DOMAIN']}/"
   puts "Backend #{name} => #{url}"
   be = Backend.find_or_initialize_by(backend_id: name)
   be.backend_url = url


### PR DESCRIPTION
Now that we have some confidence that the router is fine with HTTPS backends (we've been using it across the internet for a while), we should use HTTPS for our internal backends.

This adds a migration to upgrade all backends that are HTTP to be HTTPS and ensures that the seed only creates HTTPS backends.