### PR TITLE
Add Dockerfile and .dockerignore

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,3 @@
+.git
+.gitignore
+README.md

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,10 @@
+FROM ruby:2.2.3
+RUN apt-get update -qq && apt-get upgrade -y && apt-get install -y build-essential && apt-get clean
+
+ENV APP_HOME /app
+RUN mkdir $APP_HOME
+
+WORKDIR $APP_HOME
+ADD Gemfile* $APP_HOME/
+RUN bundle install
+ADD . $APP_HOME


### PR DESCRIPTION
The new `publishing-e2e-docker` project requires each dependent project
to have a Dockerfile.