### PR TITLE
Allow forwarding of URL segments to campaigns

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -4,3 +4,5 @@
 require File.expand_path('../config/application', __FILE__)
 
 Rails.application.load_tasks
+
+task default: [:lint]

--- a/lib/tasks/lint.rake
+++ b/lib/tasks/lint.rake
@@ -1,0 +1,4 @@
+desc "Run govuk-lint with similar params to CI"
+task "lint" do
+  sh "bundle exec govuk-lint-ruby --format clang app config Gemfile lib spec"
+end

--- a/spec/models/route_spec.rb
+++ b/spec/models/route_spec.rb
@@ -238,8 +238,18 @@ RSpec.describe Route, type: :model do
             expect(route).to be_invalid
           end
 
-          it "will reject external URLs" do
-            route.redirect_to = "http://example.com/thing"
+          it "will allow whitelisted domains" do
+            route.redirect_to = "https://moarcaek.campaign.gov.uk"
+            expect(route).to be_valid
+          end
+
+          it "will reject paths of whitelisted domains" do
+            route.redirect_to = "https://caekrecipes.campaign.gov.uk/victoria-sandwich"
+            expect(route).to be_invalid
+          end
+
+          it "will reject other external URLs" do
+            route.redirect_to = "http://example.com"
             expect(route).to be_invalid
           end
 


### PR DESCRIPTION
We are migrating our campaign formats from Publisher to the new Campaigns
platform.  Departments are using paid advertising to bring users to their
campaigns (via a short url) and want to keep the tracking data in the query string to work out
where people are coming from and therefore whether their advertising is value
for money.

This change permits *.campaign.gov.uk domain redirects to keep the query string
which contains that information.

@timblair @boffbowsh thoughts?