### PR TITLE
Allow trailing slash on URLs for external redirects

### DIFF
--- a/app/models/route.rb
+++ b/app/models/route.rb
@@ -108,10 +108,14 @@ class Route
 
   def valid_whitelisted_url?(url)
     uri = URI.parse(url)
-    return false unless uri.absolute? && uri.path.blank?
+    return false unless uri.absolute? && path_is_root_or_empty?(uri)
     belongs_to_whitelist?(uri)
   rescue URI::InvalidURIError
     false
+  end
+
+  def path_is_root_or_empty?(uri)
+    uri.path.blank? || uri.path == '/'
   end
 
   def belongs_to_whitelist?(uri)

--- a/spec/models/route_spec.rb
+++ b/spec/models/route_spec.rb
@@ -239,7 +239,7 @@ RSpec.describe Route, type: :model do
           end
 
           it "will allow whitelisted domains" do
-            route.redirect_to = "https://moarcaek.campaign.gov.uk"
+            route.redirect_to = "https://moarcaek.campaign.gov.uk/"
             expect(route).to be_valid
           end
 


### PR DESCRIPTION
I'd validated that paths were not allowed for external redirects with segments,
but had not included those ending with a slash.  Coincidentally, this is how
they are defined in router-data.