### PR TITLE
Configurable log path

### DIFF
--- a/config/application.rb
+++ b/config/application.rb
@@ -30,5 +30,7 @@ module RouterApi
     # config.i18n.default_locale = :de
 
     #config.i18n.enforce_available_locales = true
+
+    config.paths["log"] = ENV["LOG_PATH"] if ENV["LOG_PATH"]
   end
 end


### PR DESCRIPTION
This makes it relatively easy to have a differently name draft log file for
when two instances of this app are running in docker containers.