### PR TITLE
[DO NOT MERGE]Remove 301 news article routes

### DIFF
--- a/lib/tasks/delete_routes.rake
+++ b/lib/tasks/delete_routes.rake
@@ -29,6 +29,12 @@ task test_delete_collections: :environment do
   puts_routes_count(paths)
 end
 
+desc "Delete News Article 301s"
+task delete_news_articles: :environment do
+  paths = /\/news\//
+
+  delete_routes(paths)
+end
 
 def delete_routes(paths)
   routes = Route.where(incoming_path: paths, backend_id: "whitehall-frontend")


### PR DESCRIPTION
[Trello](https://trello.com/c/4tpycpbA/617-news-article-migration-5-final-tasks-deploy-10)

- These routes failed to be rendered by `government-frontend` once the rendering app for the `news-article` format was switched over from `whitehall-frontend` to `government-frontend`
- These routes were all giving a 301 Moved Permanently response, thus removing them from router