### PR TITLE
Add a route dumper

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -1,34 +1,32 @@
 #!/usr/bin/env groovy
 
-REPOSITORY = 'router-api'
+REPOSITORY = "router-api"
 
-node ('mongodb-2.4') {
-  def govuk = load '/var/lib/jenkins/groovy_scripts/govuk_jenkinslib.groovy'
+node ("mongodb-2.4") {
+  def govuk = load "/var/lib/jenkins/groovy_scripts/govuk_jenkinslib.groovy"
 
   try {
     stage("Checkout") {
-       checkout scm
+      checkout scm
     }
 
     stage("Build") {
-       sh "${WORKSPACE}/jenkins.sh"
+      sh "${WORKSPACE}/jenkins.sh"
     }
 
     stage("Push release tag") {
-       govuk.pushTag(REPOSITORY, env.BRANCH_NAME, 'release_' + env.BUILD_NUMBER)
+      govuk.pushTag(REPOSITORY, env.BRANCH_NAME, "release_" + env.BUILD_NUMBER)
     }
 
     stage("Deploy on Integration") {
-      govuk.deployIntegration(REPOSITORY, env.BRANCH_NAME, 'release', 'deploy')
+      govuk.deployIntegration(REPOSITORY, env.BRANCH_NAME, "release", "deploy")
     }
-
   } catch (e) {
     currentBuild.result = "FAILED"
-    step([$class: 'Mailer',
+    step([$class: "Mailer",
           notifyEveryUnstableBuild: true,
-          recipients: 'govuk-ci-notifications@digital.cabinet-office.gov.uk',
+          recipients: "govuk-ci-notifications@digital.cabinet-office.gov.uk",
           sendToIndividuals: true])
     throw e
   }
-
 }

--- a/lib/route_dumper.rb
+++ b/lib/route_dumper.rb
@@ -1,0 +1,28 @@
+require "csv"
+require "zlib"
+
+class RouteDumper
+  FIELDS = %w(incoming_path handler backend_id disabled redirect_to).freeze
+
+  def initialize(filename)
+    @filename = filename
+  end
+
+  def dump
+    Zlib::GzipWriter.open(filename) do |file|
+      csv = CSV.new(file)
+      csv << FIELDS + ["updated_at"]
+      routes.each do |route|
+        csv << FIELDS.map { |field| route.send(field) } + [Time.now]
+      end
+    end
+  end
+
+private
+
+  attr_reader :filename
+
+  def routes
+    Route.all
+  end
+end

--- a/lib/tasks/dump_routes.rake
+++ b/lib/tasks/dump_routes.rake
@@ -1,0 +1,7 @@
+require "route_dumper"
+
+desc "Dump routes"
+task :dump_routes, [:filename] => [:environment] do |_, args|
+  raise "Missing filename." unless args[:filename]
+  RouteDumper.new(args[:filename]).dump
+end


### PR DESCRIPTION
Add a tool for dumping the routes to a CSV file. This will be used as part of checking for inconsistent documents by sending the file to Jenkins as an artefact and will then be picked up by the `content-store`.