### PR TITLE
Remove restrictions on external prefix redirects

### DIFF
--- a/app/models/route.rb
+++ b/app/models/route.rb
@@ -17,7 +17,6 @@ class Route
   index({incoming_path: 1, route_type: 1})
 
   HANDLERS = %w(backend redirect gone)
-  WHITELISTED_DOMAIN_SUFFIXES = %w(.campaign.gov.uk)
 
   DUPLICATE_KEY_ERROR = 11000
 
@@ -108,18 +107,9 @@ class Route
 
   def valid_whitelisted_url?(url)
     uri = URI.parse(url)
-    return false unless uri.absolute? && path_is_root_or_empty?(uri)
-    belongs_to_whitelist?(uri)
+    uri.absolute?
   rescue URI::InvalidURIError
     false
-  end
-
-  def path_is_root_or_empty?(uri)
-    uri.path.blank? || uri.path == '/'
-  end
-
-  def belongs_to_whitelist?(uri)
-    WHITELISTED_DOMAIN_SUFFIXES.any? { |suffix| uri.host.end_with? suffix}
   end
 
   def valid_local_path?(path)

--- a/spec/models/route_spec.rb
+++ b/spec/models/route_spec.rb
@@ -205,7 +205,7 @@ RSpec.describe Route, type: :model do
           end
 
           it "will allow external URLs" do
-            route.redirect_to = "http://example.com/thing"
+            route.redirect_to = "http://example.service.gov.uk/thing"
             expect(route).to be_valid
           end
 

--- a/spec/models/route_spec.rb
+++ b/spec/models/route_spec.rb
@@ -238,14 +238,9 @@ RSpec.describe Route, type: :model do
             expect(route).to be_invalid
           end
 
-          it "will allow whitelisted domains" do
+          it "will allow domains within .gov.uk" do
             route.redirect_to = "https://moarcaek.campaign.gov.uk/"
             expect(route).to be_valid
-          end
-
-          it "will reject paths of whitelisted domains" do
-            route.redirect_to = "https://caekrecipes.campaign.gov.uk/victoria-sandwich"
-            expect(route).to be_invalid
           end
 
           it "will reject other external URLs" do

--- a/spec/models/route_spec.rb
+++ b/spec/models/route_spec.rb
@@ -136,6 +136,18 @@ RSpec.describe Route, type: :model do
     context "with handler set to 'redirect'" do
       subject(:route) { FactoryGirl.build(:redirect_route) }
 
+      context "with an external redirect" do
+        it "will allow .gov.uk subdomains" do
+          route.redirect_to = "http://example.service.gov.uk/thing"
+          expect(route).to be_valid
+        end
+
+        it "won't allow domains outside of .gov.uk" do
+          route.redirect_to = "http://example.service.gov.uk.example.com/thing"
+          expect(route).to be_invalid
+        end
+      end
+
       describe "segments_mode field" do
         it "is required" do
           route.segments_mode = ""

--- a/spec/models/route_spec.rb
+++ b/spec/models/route_spec.rb
@@ -53,7 +53,7 @@ RSpec.describe Route, type: :model do
         ].each do |path|
           route.incoming_path = path
           expect(route).not_to be_valid
-          expect(route.errors[:incoming_path].size).to eq(1)
+          expect(route.errors[:incoming_path]).not_to be_empty
         end
       end
 
@@ -67,7 +67,7 @@ RSpec.describe Route, type: :model do
         ].each do |path|
           route.incoming_path = path
           expect(route).not_to be_valid
-          expect(route.errors[:incoming_path].size).to eq(1)
+          expect(route.errors[:incoming_path]).not_to be_empty
         end
       end
 
@@ -257,7 +257,7 @@ RSpec.describe Route, type: :model do
             ].each do |path|
               route.redirect_to = path
               expect(route).not_to be_valid
-              expect(route.errors[:redirect_to].size).to eq(1)
+              expect(route.errors[:redirect_to]).not_to be_empty
             end
           end
         end


### PR DESCRIPTION
This is to allow for redirecting trade tariff requests to the service
domain.