### PR TITLE
Allow redirects to british-business-bank.co.uk

### DIFF
--- a/app/models/route.rb
+++ b/app/models/route.rb
@@ -124,15 +124,14 @@ class Route
 
   def validate_external_target(target)
     uri = URI.parse(target)
-    puts "#{target} #{uri.host}"
     errors[:redirect_to] << "must be an absolute URI" unless uri.absolute?
 
     return unless errors[:redirect_to].empty? # Don't continue, as the
                                               # host validation may
                                               # fail
 
-    errors[:redirect_to] << "external domain must be within .gov.uk" unless
-      uri.host.end_with?(".gov.uk")
+    errors[:redirect_to] << "external domain must be within .gov.uk or british-business-bank.co.uk" unless
+      uri.host.end_with?(".gov.uk") || uri.host == "british-business-bank.co.uk"
   rescue URI::InvalidURIError
     errors[:redirect_to] << "is an invalid URI"
   end

--- a/spec/models/route_spec.rb
+++ b/spec/models/route_spec.rb
@@ -255,6 +255,16 @@ RSpec.describe Route, type: :model do
             expect(route).to be_valid
           end
 
+          it "will allow british-business-bank.co.uk URLs" do
+            route.redirect_to = "https://british-business-bank.co.uk/banking-things"
+            expect(route).to be_valid
+          end
+
+          it "will reject british-business-bank.co.uk subdomains" do
+            route.redirect_to = "https://www.british-business-bank.co.uk"
+            expect(route).to be_invalid
+          end
+
           it "will reject other external URLs" do
             route.redirect_to = "http://example.com"
             expect(route).to be_invalid


### PR DESCRIPTION
We have four external redirects that do not go to a .gov.uk subdomain. These
all [go to the same file][1] on [http://british-business-bank.co.uk][2].  

These URLs are causing deploys of router-data to fail because router-api 
currently only allows gov.uk subdomains for external redirects. We still need to 
support these as we used to run applications supporting the Enterprise Finance
Guarantee before it was passed on to them.

Because of this, I'm extending the whitelist to include that domain too.  I've
checked the router database and we don't have redirects to any other non-gov.uk
domains, so hopefully this will remain a one off.

[1]: https://github.digital.cabinet-office.gov.uk/gds/router-data/blob/880166e47ecd79646db492043a05db994a7c8c2f/data/external-redirects.csv#L14-L17
[2]: http://british-business-bank.co.uk/wp-content/uploads/2015/02/BBB-011114-44-EFG-business-sectors-and-purposes.pdf