### PR TITLE
Add a migration which fixes references to specialist-frontend

### DIFF
--- a/db/migrate/20170816114459_fix_old_specialist_publisher_routes.rb
+++ b/db/migrate/20170816114459_fix_old_specialist_publisher_routes.rb
@@ -1,0 +1,17 @@
+class FixOldSpecialistPublisherRoutes < Mongoid::Migration
+  def self.up
+    Route.where(backend_id: "specialist-frontend").each do |route|
+      route.backend_id = "government-frontend"
+      route.save!
+    end
+
+    if RouterReloader.reload
+      puts "Router reloaded"
+    else
+      puts "Failed to reload router"
+    end
+  end
+
+  def self.down
+  end
+end


### PR DESCRIPTION
There are a few routes which still reference specialist-frontend
when they should be pointing to government-frontend. We've already
applied a migration on the content store, but there are still
some routes remaining.