### PR TITLE
Add set_router_reload_urls_from_file method

### DIFF
--- a/config/initializers/router_reloader.rb
+++ b/config/initializers/router_reloader.rb
@@ -3,6 +3,9 @@ require 'router_reloader'
 if ENV['ROUTER_NODES'].present?
   RouterReloader.set_router_reload_urls_from_string(ENV['ROUTER_NODES'])
 
+elsif ENV['ROUTER_NODES_FILE'].present?
+  RouterReloader.set_router_reload_urls_from_file(ENV['ROUTER_NODES_FILE'])
+
 elsif ! Rails.env.production?
   RouterReloader.router_reload_urls = ["http://localhost:3055/reload"]
 

--- a/lib/router_reloader.rb
+++ b/lib/router_reloader.rb
@@ -12,6 +12,11 @@ class RouterReloader
     self.router_reload_urls = nodes.map {|node| "http://#{node}/reload" }
   end
 
+  def self.set_router_reload_urls_from_file(router_nodes_file)
+    nodes = File.readlines(router_nodes_file).map(&:chomp)
+    self.router_reload_urls = nodes.map {|node| "http://#{node}/reload" }
+  end
+
   # To be set in dev mode so that this can run when the router isn't running.
   cattr_accessor :swallow_connection_errors
 

--- a/spec/lib/router_reloader_spec.rb
+++ b/spec/lib/router_reloader_spec.rb
@@ -28,6 +28,25 @@ RSpec.describe RouterReloader do
     end
   end
 
+  describe "parsing router reload urls from env var file" do
+    around :each do |example|
+      original_urls = RouterReloader.router_reload_urls
+      example.run
+      RouterReloader.router_reload_urls = original_urls
+    end
+
+    it "should generate urls from list of host:port pairs" do
+      filename = 'spec/support/router_nodes.txt'
+
+      RouterReloader.set_router_reload_urls_from_file(filename)
+
+      expect(RouterReloader.router_reload_urls).to eq([
+        "http://foo.bar:1234/reload",
+        "http://bar.baz:2345/reload",
+      ])
+    end
+  end
+
   describe "triggering a reload of routes" do
     before :each do
       allow(RouterReloader).to receive(:router_reload_urls).and_return(["http://foo.example.com:1234/reload", "http://bar.example.com:4321/reload"])

--- a/spec/support/router_nodes.txt
+++ b/spec/support/router_nodes.txt
@@ -1,0 +1,2 @@
+foo.bar:1234
+bar.baz:2345


### PR DESCRIPTION
Traditionally we have been able to pass in the router nodes to router-api using an environment variable as we hardcoded the hostnames that the instance needed to connect to.

In a dynamic environment, such as AWS, it is no longer possible to do this as we do not choose hostnames assigned to instances.

Instead, we can create a script that will write out the current router nodes to a file. If any nodes get rebuilt or change, the file will be updated. router-api can then read this file in and connect to the relevant nodes to reload routes.