### PR TITLE
Add rack handler gem to enable unicorn in docker

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -16,4 +16,4 @@ ADD Gemfile* $APP_HOME/
 RUN bundle install
 ADD . $APP_HOME
 
-CMD bash -c "rm -f tmp/pids/server.pid && bundle exec rails s -p $PORT -b '0.0.0.0'"
+CMD bash -c "rm -f tmp/pids/server.pid && bundle exec rails s unicorn -p $PORT -b '0.0.0.0'"

--- a/Gemfile
+++ b/Gemfile
@@ -11,6 +11,7 @@ gem 'logstasher', '0.6.2'
 gem 'unicorn', '~> 4.9.0'
 
 group :development, :test do
+  gem 'rack-handlers', '~> 0.7', require: 'rack/handler/rails-server'
   gem 'rspec-rails', '~> 3.5'
   gem 'database_cleaner', '1.6.1'
   gem 'factory_girl_rails', '4.2.1'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -113,6 +113,8 @@ GEM
     plek (1.12.0)
     powerpack (0.1.1)
     rack (2.0.3)
+    rack-handlers (0.7.3)
+      rack
     rack-test (0.6.3)
       rack (>= 1.0)
     rails (5.1.1)
@@ -210,6 +212,7 @@ DEPENDENCIES
   mongoid (= 6.1.0)
   mongoid_rails_migrations!
   plek (= 1.12.0)
+  rack-handlers (~> 0.7)
   rails (= 5.1.1)
   rspec-rails (~> 3.5)
   unicorn (~> 4.9.0)


### PR DESCRIPTION
This is an attempt to fix a horrid issue we are having in
publishing-e2e-tests that began when the Rails 5.1 upgrade was merged.

Webrick seems to get caught on the first PUT request (fine if it's a
GET) and won't process any requests. This seems to resolve the problem.