### PR TITLE
Add /email/unsubscribe prefix route

### DIFF
--- a/db/migrate/20171129092558_add_email_unsubscribe_prefix_route.rb
+++ b/db/migrate/20171129092558_add_email_unsubscribe_prefix_route.rb
@@ -1,0 +1,20 @@
+class AddEmailUnsubscribePrefixRoute < Mongoid::Migration
+  def self.up
+    Route.find_or_create_by(
+      incoming_path: "/email/unsubscribe",
+      route_type: "prefix",
+      handler: "backend",
+      disabled: false,
+      backend_id: "email-alert-frontend",
+    )
+
+    if RouterReloader.reload
+      puts "Router reloaded"
+    else
+      puts "Failed to reload router"
+    end
+  end
+
+  def self.down
+  end
+end


### PR DESCRIPTION
Create a migration that will create the /email/unsubscribe prefix route

[Trello card](https://trello.com/c/M0ODsZHV/398-add-prefix-route-to-router-to-point-email-to-email-alert-frontend)