### PR TITLE
Add major version constraints to the Gemfile

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,14 +1,14 @@
 source 'https://rubygems.org'
 
-gem 'govuk_app_config'
-gem 'plek'
+gem 'govuk_app_config', '~> 1'
+gem 'plek', '~> 2'
 gem 'rails', '5.1.1'
 
 gem 'mongoid', '~> 6.2'
 gem "mongoid_rails_migrations", git: "https://github.com/alphagov/mongoid_rails_migrations", branch: "avoid-calling-bundler-require-in-library-code-v1.1.0-plus-mongoid-v5-fix"
 
 group :development, :test do
-  gem 'byebug'
+  gem 'byebug', '~> 10'
   gem 'ci_reporter_rspec', '~> 1.0.0'
   gem 'database_cleaner', '1.6.2'
   gem 'factory_girl_rails', '4.2.1'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -228,15 +228,15 @@ PLATFORMS
   ruby
 
 DEPENDENCIES
-  byebug
+  byebug (~> 10)
   ci_reporter_rspec (~> 1.0.0)
   database_cleaner (= 1.6.2)
   factory_girl_rails (= 4.2.1)
   govuk-lint (= 3.6.0)
-  govuk_app_config
+  govuk_app_config (~> 1)
   mongoid (~> 6.2)
   mongoid_rails_migrations!
-  plek
+  plek (~> 2)
   rack-handlers (~> 0.7)
   rails (= 5.1.1)
   rspec-rails (~> 3.5)


### PR DESCRIPTION
For gems with no constraint, to prevent bundle update from
automatically updating between major versions.