### PR TITLE
Change predicates to fix deprecation notices

### DIFF
--- a/spec/requests/backend_crud_spec.rb
+++ b/spec/requests/backend_crud_spec.rb
@@ -7,14 +7,14 @@ RSpec.describe "managing backends", type: :request do
 
       get "/backends/foo"
 
-      expect(response).to be_success
+      expect(response).to be_successful
       expect(JSON.parse(response.body)).to eq("backend_id" => "foo",
         "backend_url" => "http://foo.example.com/")
     end
 
     it "should 404 for a non-existent backend" do
       get "/backends/non-existent"
-      expect(response).to be_missing
+      expect(response).to be_not_found
     end
   end
 

--- a/spec/requests/healthcheck_spec.rb
+++ b/spec/requests/healthcheck_spec.rb
@@ -3,6 +3,6 @@ require 'rails_helper'
 RSpec.describe "Healthecheck", type: :request do
   it "should resposnd on a healthcheck path" do
     get "/healthcheck"
-    expect(response).to be_success
+    expect(response).to be_successful
   end
 end


### PR DESCRIPTION
The success? and missing? Rails predicates are due to be removed in
Rails 6. This resolves deprecation warnings.