### PR TITLE
Load URLs when creating the class

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -11,6 +11,7 @@ gem "mongoid_rails_migrations", git: "https://github.com/alphagov/mongoid_rails_
 group :development, :test do
   gem 'byebug', '~> 10'
   gem 'ci_reporter_rspec', '~> 1.0'
+  gem 'climate_control', '~> 0.2'
   gem 'database_cleaner', '~> 1.7'
   gem 'factory_bot_rails', '~> 4.8'
   gem 'govuk-lint', '~> 3.8'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -66,6 +66,7 @@ GEM
     ci_reporter_rspec (1.0.0)
       ci_reporter (~> 2.0)
       rspec (>= 2.14, < 4)
+    climate_control (0.2.0)
     concurrent-ruby (1.0.5)
     crack (0.4.3)
       safe_yaml (~> 1.0.0)
@@ -237,6 +238,7 @@ PLATFORMS
 DEPENDENCIES
   byebug (~> 10)
   ci_reporter_rspec (~> 1.0)
+  climate_control (~> 0.2)
   database_cleaner (~> 1.7)
   factory_bot_rails (~> 4.8)
   govuk-lint (~> 3.8)

--- a/config/initializers/router_reloader.rb
+++ b/config/initializers/router_reloader.rb
@@ -1,7 +1,0 @@
-require 'router_reloader'
-
-if Rails.env.development?
-  # In development we want to attempt to reload the router, but not
-  # fail if the router isn't running.
-  RouterReloader.swallow_connection_errors = true
-end

--- a/config/initializers/router_reloader.rb
+++ b/config/initializers/router_reloader.rb
@@ -1,19 +1,5 @@
 require 'router_reloader'
 
-if ENV['ROUTER_NODES'].present?
-  RouterReloader.set_router_reload_urls_from_string(ENV['ROUTER_NODES'])
-
-elsif ENV['ROUTER_NODES_FILE'].present?
-  RouterReloader.set_router_reload_urls_from_file(ENV['ROUTER_NODES_FILE'])
-
-elsif ! Rails.env.production?
-  RouterReloader.router_reload_urls = ["http://localhost:3055/reload"]
-
-else
-  raise "No router nodes provided.  Need to set the ROUTER_NODES env variable"
-
-end
-
 if Rails.env.development?
   # In development we want to attempt to reload the router, but not
   # fail if the router isn't running.

--- a/db/seeds/zz_reload_routes.rb
+++ b/db/seeds/zz_reload_routes.rb
@@ -1,5 +1,3 @@
-require 'router_reloader'
+require "router_reloader"
 
-# The router isn't running when this is called on the CI box.
-RouterReloader.swallow_connection_errors = true unless Rails.env.production?
 RouterReloader.reload

--- a/lib/router_reloader.rb
+++ b/lib/router_reloader.rb
@@ -19,10 +19,6 @@ class RouterReloader
     end
   end
 
-  def swallow_connection_errors?
-    Rails.env.development?
-  end
-
   def reload
     errors = post_reload_urls.compact
     return true if errors.empty?
@@ -40,6 +36,10 @@ class RouterReloader
   end
 
 private
+
+  def swallow_connection_errors?
+    Rails.env.test? || Rails.env.development?
+  end
 
   def post_reload_urls
     urls.map do |url|

--- a/lib/router_reloader.rb
+++ b/lib/router_reloader.rb
@@ -1,4 +1,4 @@
-require 'net/http'
+require "net/http"
 
 class RouterReloader
   def self.reload
@@ -6,7 +6,7 @@ class RouterReloader
   end
 
   def self.urls_from_string(string)
-    nodes = string.split(',').map(&:strip)
+    nodes = string.split(",").map(&:strip)
     nodes.map { |node| "http://#{node}/reload" }
   end
 

--- a/lib/router_reloader.rb
+++ b/lib/router_reloader.rb
@@ -5,16 +5,24 @@ class RouterReloader
     new(router_reload_urls).reload
   end
 
+  def self.urls_from_string(string)
+    nodes = string.split(',').map(&:strip)
+    nodes.map { |node| "http://#{node}/reload" }
+  end
+
+  def self.urls_from_file(filename)
+    nodes = File.readlines(filename).map(&:chomp)
+    nodes.map { |node| "http://#{node}/reload" }
+  end
+
   # set from an initializer
   cattr_accessor :router_reload_urls
   def self.set_router_reload_urls_from_string(router_nodes_str)
-    nodes = router_nodes_str.split(',').map(&:strip)
-    self.router_reload_urls = nodes.map { |node| "http://#{node}/reload" }
+    self.router_reload_urls = urls_from_string(router_nodes_str)
   end
 
   def self.set_router_reload_urls_from_file(router_nodes_file)
-    nodes = File.readlines(router_nodes_file).map(&:chomp)
-    self.router_reload_urls = nodes.map { |node| "http://#{node}/reload" }
+    self.router_reload_urls = urls_from_file(router_nodes_file)
   end
 
   # To be set in dev mode so that this can run when the router isn't running.

--- a/lib/router_reloader.rb
+++ b/lib/router_reloader.rb
@@ -5,9 +5,6 @@ class RouterReloader
     new.reload
   end
 
-  # To be set in dev mode so that this can run when the router isn't running.
-  cattr_accessor :swallow_connection_errors
-
   def urls
     @urls ||= begin
       if ENV["ROUTER_NODES"].present?
@@ -20,6 +17,10 @@ class RouterReloader
         raise "No router nodes provided. Need to set the ROUTER_NODES env variable"
       end
     end
+  end
+
+  def swallow_connection_errors?
+    Rails.env.development?
   end
 
   def reload
@@ -37,7 +38,7 @@ class RouterReloader
     end
     true
   rescue Errno::ECONNREFUSED
-    raise unless self.class.swallow_connection_errors
+    raise unless swallow_connection_errors?
     true
   end
 

--- a/spec/lib/router_reloader_spec.rb
+++ b/spec/lib/router_reloader_spec.rb
@@ -3,32 +3,27 @@ require 'router_reloader'
 
 RSpec.describe RouterReloader do
   describe "parsing router reload urls from env var string" do
+    let(:expected_urls) { ["http://foo.bar:1234/reload", "http://bar.baz:2345/reload"] }
+
     it "should generate urls from list of host:port pairs" do
       ClimateControl.modify ROUTER_NODES: "foo.bar:1234,bar.baz:2345" do
-        expect(subject.urls).to eq([
-          "http://foo.bar:1234/reload",
-          "http://bar.baz:2345/reload",
-        ])
+        expect(subject.urls).to eq(expected_urls)
       end
     end
 
     it "should cope with extra whitespace in the string" do
       ClimateControl.modify ROUTER_NODES: "  foo.bar:1234,bar.baz:2345 \n" do
-        expect(subject.urls).to eq([
-          "http://foo.bar:1234/reload",
-          "http://bar.baz:2345/reload",
-        ])
+        expect(subject.urls).to eq(expected_urls)
       end
     end
   end
 
   describe "parsing router reload urls from env var file" do
+    let(:expected_urls) { ["http://foo.bar:1234/reload", "http://bar.baz:2345/reload"] }
+
     it "should generate urls from list of host:port pairs" do
       ClimateControl.modify ROUTER_NODES_FILE: "spec/support/router_nodes.txt" do
-        expect(subject.urls).to eq([
-          "http://foo.bar:1234/reload",
-          "http://bar.baz:2345/reload",
-        ])
+        expect(subject.urls).to eq(expected_urls)
       end
     end
   end

--- a/spec/lib/router_reloader_spec.rb
+++ b/spec/lib/router_reloader_spec.rb
@@ -3,60 +3,48 @@ require 'router_reloader'
 
 RSpec.describe RouterReloader do
   describe "parsing router reload urls from env var string" do
-    around :each do |example|
-      original_urls = RouterReloader.router_reload_urls
-      example.run
-      RouterReloader.router_reload_urls = original_urls
-    end
-
     it "should generate urls from list of host:port pairs" do
-      RouterReloader.set_router_reload_urls_from_string("foo.bar:1234,bar.baz:2345")
-
-      expect(RouterReloader.router_reload_urls).to eq([
-        "http://foo.bar:1234/reload",
-        "http://bar.baz:2345/reload",
-      ])
+      ClimateControl.modify ROUTER_NODES: "foo.bar:1234,bar.baz:2345" do
+        expect(subject.urls).to eq([
+          "http://foo.bar:1234/reload",
+          "http://bar.baz:2345/reload",
+        ])
+      end
     end
 
     it "should cope with extra whitespace in the string" do
-      RouterReloader.set_router_reload_urls_from_string(" foo.bar:1234, bar.baz:2345 \n")
-
-      expect(RouterReloader.router_reload_urls).to eq([
-        "http://foo.bar:1234/reload",
-        "http://bar.baz:2345/reload",
-      ])
+      ClimateControl.modify ROUTER_NODES: "  foo.bar:1234,bar.baz:2345 \n" do
+        expect(subject.urls).to eq([
+          "http://foo.bar:1234/reload",
+          "http://bar.baz:2345/reload",
+        ])
+      end
     end
   end
 
   describe "parsing router reload urls from env var file" do
-    around :each do |example|
-      original_urls = RouterReloader.router_reload_urls
-      example.run
-      RouterReloader.router_reload_urls = original_urls
-    end
-
     it "should generate urls from list of host:port pairs" do
-      filename = 'spec/support/router_nodes.txt'
-
-      RouterReloader.set_router_reload_urls_from_file(filename)
-
-      expect(RouterReloader.router_reload_urls).to eq([
-        "http://foo.bar:1234/reload",
-        "http://bar.baz:2345/reload",
-      ])
+      ClimateControl.modify ROUTER_NODES_FILE: "spec/support/router_nodes.txt" do
+        expect(subject.urls).to eq([
+          "http://foo.bar:1234/reload",
+          "http://bar.baz:2345/reload",
+        ])
+      end
     end
   end
 
   describe "triggering a reload of routes" do
     before :each do
-      allow(RouterReloader).to receive(:router_reload_urls).and_return(["http://foo.example.com:1234/reload", "http://bar.example.com:4321/reload"])
+      allow(subject).to receive(:urls).and_return(
+        ["http://foo.example.com:1234/reload", "http://bar.example.com:4321/reload"]
+      )
     end
 
     it "should POST to the reload endpoint on all the configured routers, and return true" do
       r1 = stub_request(:post, "http://foo.example.com:1234/reload").to_return(status: 200)
       r2 = stub_request(:post, "http://bar.example.com:4321/reload").to_return(status: 202)
 
-      expect(RouterReloader.reload).to be_truthy
+      expect(subject.reload).to be_truthy
 
       expect(r1).to have_been_requested.once
       expect(r2).to have_been_requested.once
@@ -73,14 +61,14 @@ RSpec.describe RouterReloader do
           expect(errors[0]).to eq(url: "http://foo.example.com:1234/reload", status: "401", body: "Authorisation required")
           expect(errors[1]).to eq(url: "http://bar.example.com:4321/reload", status: "404", body: "Not found")
         }
-        expect(RouterReloader.reload).to be_falsey
+        expect(subject.reload).to be_falsey
       end
 
       it "should still reload subsequent hosts on error" do
         stub_request(:post, "http://foo.example.com:1234/reload").to_return(status: 401, body: "Authorisation required")
         r2 = stub_request(:post, "http://bar.example.com:4321/reload").to_return(status: 202)
 
-        RouterReloader.reload
+        subject.reload
 
         expect(r2).to have_been_requested.once
       end
@@ -89,7 +77,7 @@ RSpec.describe RouterReloader do
         stub_request(:post, "http://foo.example.com:1234/reload").to_raise(Errno::ECONNREFUSED)
 
         expect {
-          RouterReloader.reload
+          subject.reload
         }.to raise_error(Errno::ECONNREFUSED)
       end
 
@@ -97,7 +85,7 @@ RSpec.describe RouterReloader do
         allow(RouterReloader).to receive(:swallow_connection_errors).and_return(true)
         stub_request(:post, "http://foo.example.com:1234/reload").to_raise(Errno::ECONNREFUSED)
 
-        expect(RouterReloader.reload).to eq(true)
+        expect(subject.reload).to eq(true)
       end
     end
   end

--- a/spec/lib/router_reloader_spec.rb
+++ b/spec/lib/router_reloader_spec.rb
@@ -82,7 +82,7 @@ RSpec.describe RouterReloader do
       end
 
       it "should swallow connection refused errors when configured to" do
-        allow(RouterReloader).to receive(:swallow_connection_errors).and_return(true)
+        allow(subject).to receive(:swallow_connection_errors?).and_return(true)
         stub_request(:post, "http://foo.example.com:1234/reload").to_raise(Errno::ECONNREFUSED)
 
         expect(subject.reload).to eq(true)

--- a/spec/support/router_reload_stubs.rb
+++ b/spec/support/router_reload_stubs.rb
@@ -1,13 +1,13 @@
-require 'router_reloader'
+require "router_reloader"
 
 module RouterReloadStubs
   def setup_router_reload_http_stub
     # Assume it's only configured with a single URL in development/test
-    @router_reload_http_stub = WebMock.stub_request(:post, RouterReloader.router_reload_urls.first)
+    @router_reload_http_stub = WebMock.stub_request(:post, RouterReloader.new.urls.first)
   end
 
   def stub_router_reload_error
-    WebMock.stub_request(:post, RouterReloader.router_reload_urls.first).
+    WebMock.stub_request(:post, RouterReloader.new.urls.first).
       to_return(status: 500, body: "Error")
   end
 


### PR DESCRIPTION
At the moment we load URLs when the app starts and they are used for the entire lifetime of the app. In AWS environments, the file which contains the list of Router nodes [gets updated every 5 seconds](https://github.com/alphagov/govuk-puppet/blob/673bc9ae8a00c3f542ad6f3d37ee9b2b3fbb30e0/modules/govuk/manifests/apps/router_api.pp#L89-L94) so we should make sure we load these URLs whenever we want to perform a route reload rather than once at the beginning.

I've also refactored the class to be easier to understand.

[Trello Card](https://trello.com/c/aEzYZWIR/169-router-api-cant-handle-router-changing-hostname-2)