### PR TITLE
Set rubyLintDiff to false in the Jenkinsfile

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -9,6 +9,7 @@ repoName = JOB_NAME.split('/')[0]
 node ("mongodb-2.4") {
   govuk.buildProject(
     publishingE2ETests: true,
+    rubyLintDiff: false,
     brakeman: true,
     afterTest: {
       govuk.setEnvar("GOVUK_APP_DOMAIN", "test.gov.uk")


### PR DESCRIPTION
To ensure all the code is linted all the time.