### PR TITLE
DocumentDB support

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -9,6 +9,9 @@ ENV RAILS_ENV development
 ENV ROUTER_NODES router:3055
 ENV TEST_MONGODB_URI mongodb://mongo/router-test
 
+# place the AWS RDS Certificate Authority bundle at well known path
+RUN wget -O /etc/ssl/certs/rds-cacert.pem https://s3.amazonaws.com/rds-downloads/rds-combined-ca-bundle.pem
+
 ENV APP_HOME /app
 RUN mkdir $APP_HOME
 

--- a/config/mongoid.yml
+++ b/config/mongoid.yml
@@ -18,6 +18,7 @@ test:
         max_retries: 1
         retry_interval: 0
 
+
 production:
   clients:
     default:
@@ -25,3 +26,4 @@ production:
       options:
         write:
           w: 1
+        ssl_ca_cert: /etc/ssl/certs/rds_cacert.pem


### PR DESCRIPTION
## What

Tweaks required for running `router-api` with a DocumentDB backend.

## Why

Nobody wants to manage mongo boxes if we don't have to