### PR TITLE
Correct backend_id for statistics pages

### DIFF
--- a/lib/tasks/backend_ids.rake
+++ b/lib/tasks/backend_ids.rake
@@ -1,13 +1,7 @@
 namespace :backend_ids do
   task fix: :environment do
     affected_base_paths = %w(
-      /government/statistics/labour-market-statistics-may-2015
-      /government/statistics/equality-statistics-for-the-northern-ireland-civil-service-1-jan-2017
-      /government/statistics/personnel-statistics-for-the-nics-based-on-staff-in-post-at-1-april-2017
-      /government/statistics/announcements/animal-feed-production-for-great-britain-august-2016
-      /government/statistics/announcements/vocational-and-other-qualifications-quarterly-january-to-march-2017
-      /government/statistics/announcements/weekly-all-cause-mortality-surveillance-weeks-ending-6-august-2017-and-13-august-2017
-      /government/publications/information-on-plans-for-payment-by-results-in-2013-to-2014
+      /government/statistics/announcements/farming-statistics-provisional-crop-areas-yields-and-livestock-populations-at-1-june-2019-uk
     )
 
     affected_base_paths.each do |base_path|


### PR DESCRIPTION
This is a quick fix for a statistics page with an incorrect
backend_id. The page is rendered by whitehall-frontend, but
should be rendered by government-frontend, like other stats
announcements.

There are ~1,000 other stats announcements affected, so we'll
probably need to run this for the others in future once we have
fixed the underlying bug.

Zendesk ticket: https://govuk.zendesk.com/agent/tickets/3773523