### PR TITLE
Use the combined Amazon cert bundle for RDS/DocDB.

### DIFF
--- a/config/mongoid.yml
+++ b/config/mongoid.yml
@@ -26,4 +26,4 @@ production:
       options:
         write:
           w: 1
-        ssl_ca_cert: /etc/ssl/certs/rds_cacert.pem
+        ssl_ca_cert: /etc/ssl/certs/rds-combined-ca-bundle.pem


### PR DESCRIPTION
This isn't actually in use yet since we're still on self-hosted Mongo,
so this is functionally a no-op for now.

It means that when we come to switch `router-api` to DocumentDB, the cert
file will still be in the right place after alphagov/govuk-puppet#9839.