### PR TITLE
Fix RDS cert bundle filename in Docker image.

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -10,7 +10,7 @@ ENV ROUTER_NODES router:3055
 ENV TEST_MONGODB_URI mongodb://mongo/router-test
 
 # place the AWS RDS Certificate Authority bundle at well known path
-RUN wget -O /etc/ssl/certs/rds-cacert.pem https://s3.amazonaws.com/rds-downloads/rds-combined-ca-bundle.pem
+RUN wget -O /etc/ssl/certs/rds-combined-ca-bundle.pem https://s3.amazonaws.com/rds-downloads/rds-combined-ca-bundle.pem
 
 ENV APP_HOME /app
 RUN mkdir $APP_HOME


### PR DESCRIPTION
When updating the cert bundle in #269 I changed its filename to the one
that Amazon uses so that it's easy to find next time it needs updating.
I didn't spot that it also appears in the Docker images.