### PR TITLE
Correct redirect_coronavirus rake task

### DIFF
--- a/lib/tasks/redirect.rake
+++ b/lib/tasks/redirect.rake
@@ -1,5 +1,6 @@
+require "router_reloader"
 desc "Redirects the coronavirus topical event page to new landing page"
-task redirect_coronavirus: :enviroment do
+task redirect_coronavirus: :environment do
   old = "/government/topical-events/coronavirus-covid-19-uk-government-response"
   new = "/coronavirus"
   redirect(old, new)


### PR DESCRIPTION
There was a spelling mistake in the original PR.