### PR TITLE
Use the internal signon url

### DIFF
--- a/config/initializers/gds_sso.rb
+++ b/config/initializers/gds_sso.rb
@@ -6,7 +6,7 @@ GDS::SSO.config do |config|
   config.oauth_secret = ENV["OAUTH_SECRET"]
 
   # optional config for location of Signon
-  config.oauth_root_url = Plek.new.external_url_for("signon")
+  config.oauth_root_url = Plek.find("signon")
 
   # Pass in a caching adapter cache bearer token requests.
   config.cache = Rails.cache


### PR DESCRIPTION
This is useful if we don't have DNS records set up for the external URLs, as in the test environment.

```
> Plek.find("signon")
=> "https://signon.test.govuk-internal.digital"
> Plek.new.external_url_for("signon")
=> "https://signon.test.publishing.service.gov.uk"
```

See e.g. publishing-api:
https://github.com/alphagov/publishing-api/blob/a899ce1cf24c7aaac97cb8262297fbeb4331d23e/config/initializers/gds_sso.rb
