### PR TITLE
Force Router to reload routes on startup

### DIFF
--- a/config/application.rb
+++ b/config/application.rb
@@ -31,3 +31,7 @@ module RouterApi
     config.paths["log"] = ENV["LOG_PATH"] if ENV["LOG_PATH"]
   end
 end
+
+# Trigger refresh of routes in Router (ensures Router is up to date post data sync)
+require_relative "../lib/router_reloader.rb"
+RouterReloader.reload


### PR DESCRIPTION
After a data sync, many routes will have changed, and in fact are
correctly applied in Router API. However, we believe that Router
itself is not updated (at least until a route is changed on
Staging / Integration, whereupon it fixes itself).

More often than not, this goes by unnoticed, but being out of date
with the Router on Production can cause strange errors. For
[example][sentry], a redirect applied on Production but not
applied on Staging/Integration can cause taxonomy errors
("Tried to render a taxon page for content item that is not a
taxon") when the Production requests are
[shadowed to Staging][goreplay].

Therefore, this commit makes a call to Router to reload its routes
when Router API is started up. After a data sync, apps such as
Router API are restarted, so this should ensure that Router remains
in sync with Router API.

I did [consider][pr] adding some explicit routes reload logic in the
post data-sync job in govuk-puppet instead, but as it is Router
API's responsibility to keep Router update, it makes sense to me to
internalise as much of that logic as possible.

[goreplay]: https://docs.publishing.service.gov.uk/manual/alerts/goreplay.html
[pr]: https://github.com/alphagov/govuk-puppet/pull/10908
[sentry]: https://sentry.io/organizations/govuk/issues/2122080074/?project=202213&query=is%3Aunresolved