### PR TITLE
Allow redirects to judiciary.uk

### DIFF
--- a/app/models/route.rb
+++ b/app/models/route.rb
@@ -131,8 +131,8 @@ private
 
     return unless errors[:redirect_to].empty? # Don't continue, as the host validation may fail
 
-    errors[:redirect_to] << "external domain must be within .gov.uk or british-business-bank.co.uk" unless
-      uri.host.end_with?(".gov.uk") || uri.host == "british-business-bank.co.uk"
+    errors[:redirect_to] << "external domain must be within .gov.uk, .judiciary.uk or british-business-bank.co.uk" unless
+      uri.host.end_with?(".gov.uk") || uri.host.end_with?(".judiciary.uk") || uri.host == "british-business-bank.co.uk"
   rescue URI::InvalidURIError
     errors[:redirect_to] << "is an invalid URI"
   end

--- a/spec/models/route_spec.rb
+++ b/spec/models/route_spec.rb
@@ -255,6 +255,11 @@ RSpec.describe Route, type: :model do
             expect(route).to be_valid
           end
 
+          it "will allow domains within .judiciary.uk" do
+            route.redirect_to = "https://www.judiciary.uk/"
+            expect(route).to be_valid
+          end
+
           it "will allow british-business-bank.co.uk URLs" do
             route.redirect_to = "https://british-business-bank.co.uk/banking-things"
             expect(route).to be_valid


### PR DESCRIPTION
We recently added support for this in Publishing API (https://github.com/alphagov/publishing-api/pull/1897) and Whitehall (https://github.com/alphagov/whitehall/pull/5972) but not in Router API, so the redirects weren't ending up in Router correctly.

[Trello Card](https://trello.com/c/138P3vIk)