### PR TITLE
Add subdomain names to backends

### DIFF
--- a/app/models/backend.rb
+++ b/app/models/backend.rb
@@ -4,6 +4,7 @@ class Backend
 
   field :backend_id, type: String
   field :backend_url, type: String
+  field :subdomain_name, type: String
 
   index({ backend_id: 1 }, unique: true)
 

--- a/app/models/backend.rb
+++ b/app/models/backend.rb
@@ -9,6 +9,7 @@ class Backend
   index({ backend_id: 1 }, unique: true)
 
   validates :backend_id, presence: true, uniqueness: true, format: { with: /\A[a-z0-9-]*\z/ }
+  validates :subdomain_name, format: { with: /\A[a-z0-9-.]*\z/ }
   validate :validate_backend_url
 
   before_destroy :ensure_no_linked_routes

--- a/lib/tasks/backend.rake
+++ b/lib/tasks/backend.rake
@@ -1,4 +1,43 @@
 namespace :backend do
+  desc "Adds a subdomain to all backends"
+  task add_subdomains: :environment do
+    subdomain_mappings = {
+      "content-store" => "content-store",
+      "calculators" => "calculators",
+      "email-alert-frontend" => "email-alert-frontend",
+      "manuals-frontend" => "manuals-frontend",
+      "info-frontend" => "info-frontend",
+      "government-frontend" => "government-frontend",
+      "email-campaign-frontend" => "email-campaign-frontend",
+      "finder-frontend" => "finder-frontend",
+      "whitehall-frontend" => "whitehall-frontend",
+      "smartanswers" => "smartanswers",
+      "service-manual-frontend" => "service-manual-frontend",
+      "frontend" => "frontend",
+      "feedback" => "feedback",
+      "licensify" => "licensify",
+      "canary-frontend" => "canary-frontend",
+      "licencefinder" => "licencefinder",
+      "collections" => "collections",
+      "static" => "static",
+      "contacts-frontend" => "contacts-frontend",
+      "search-api" => "search-api",
+    }
+    subdomain_mappings.each do |backend_id, subdomain|
+      backend = Backend.find_by(backend_id: backend_id)
+      unless backend
+        puts "couldn't find backend '#{backend_id}'"
+        next
+      end
+      puts "Changing #{backend_id} subdomain from '#{backend.subdomain_name}' to '#{subdomain}'"
+      backend.subdomain_name = subdomain
+      backend.save!
+    end
+
+    puts "Reloading router"
+    RouterReloader.reload
+  end
+
   desc "Updates backend_url for a given backend"
   task :modify_url, %i[backend_id backend_url] => [:environment] do |_t, args|
     unless args[:backend_id] && args[:backend_url]

--- a/spec/requests/backend_crud_spec.rb
+++ b/spec/requests/backend_crud_spec.rb
@@ -11,6 +11,7 @@ RSpec.describe "managing backends", type: :request do
       expect(JSON.parse(response.body)).to eq(
         "backend_id" => "foo",
         "backend_url" => "http://foo.example.com/",
+        "subdomain_name" => nil,
       )
     end
 
@@ -28,6 +29,7 @@ RSpec.describe "managing backends", type: :request do
       expect(JSON.parse(response.body)).to eq(
         "backend_id" => "foo",
         "backend_url" => "http://foo.example.com/",
+        "subdomain_name" => nil,
       )
 
       backend = Backend.where(backend_id: "foo").first
@@ -45,6 +47,7 @@ RSpec.describe "managing backends", type: :request do
         "errors" => {
           "backend_url" => ["is not a valid HTTP URL"],
         },
+        "subdomain_name" => nil,
       )
 
       backend = Backend.where(backend_id: "foo").first
@@ -65,12 +68,13 @@ RSpec.describe "managing backends", type: :request do
   describe "updating a backend" do
     it "should update the backend" do
       backend = FactoryBot.create(:backend, backend_id: "foo", backend_url: "http://something.example.com/")
-      put_json "/backends/foo", backend: { backend_url: "http://something-else.example.com/" }
+      put_json "/backends/foo", backend: { backend_url: "http://something-else.example.com/", "subdomain_name" => "something-else" }
 
       expect(response.code.to_i).to eq(200)
       expect(JSON.parse(response.body)).to eq(
         "backend_id" => "foo",
         "backend_url" => "http://something-else.example.com/",
+        "subdomain_name" => "something-else",
       )
 
       backend.reload
@@ -79,7 +83,7 @@ RSpec.describe "managing backends", type: :request do
 
     it "should return an error if given invalid data" do
       backend = FactoryBot.create(:backend, backend_id: "foo", backend_url: "http://something.example.com/")
-      put_json "/backends/foo", backend: { backend_url: "" }
+      put_json "/backends/foo", backend: { backend_url: "", "subdomain_name" => "https://a-url.example.com/" }
 
       expect(response.code.to_i).to eq(422)
       expect(JSON.parse(response.body)).to eq(
@@ -87,7 +91,9 @@ RSpec.describe "managing backends", type: :request do
         "backend_url" => "",
         "errors" => {
           "backend_url" => ["is not a valid HTTP URL"],
+          "subdomain_name" => ["is invalid"],
         },
+        "subdomain_name" => "https://a-url.example.com/",
       )
 
       backend.reload
@@ -107,6 +113,7 @@ RSpec.describe "managing backends", type: :request do
       expect(JSON.parse(response.body)).to eq(
         "backend_id" => "foo",
         "backend_url" => "http://foo.example.com/",
+        "subdomain_name" => nil,
       )
 
       backend = Backend.where(backend_id: "foo").first
@@ -125,6 +132,7 @@ RSpec.describe "managing backends", type: :request do
         "errors" => {
           "base" => ["Backend has routes - can't delete"],
         },
+        "subdomain_name" => nil,
       )
 
       backend = Backend.where(backend_id: "foo").first


### PR DESCRIPTION
## Problem

During the migration to ECS, Replatforming intends to run router in ECS and EC2, using the same backing database managed by Router API, hosted in EC2.

One problem with this approach is that ECS and EC2 apps are served at different domains (as below),

- https://calendars.integration.govuk-internal.digital/
- http://calendars.mesh.govuk-internal.digital/

Router looks up the entire backend_url from its database. This currently makes it impossible to run two different Router
applications which serve different domains, but use the same database.

```
GET /search -> https://finder-frontend.integration.govuk-internal.digital
GET /search -> http://finder-frontend.mesh.ecs.govuk-internal.digital
```

## Solution

We'll add an unqualified (or partially qualified) domain name to Backends which will have a domain name appended to it [at runtime by Router](https://github.com/alphagov/router/pull/188).

`subdomain_name` will be a partially qualified domain name (e.g. 'content-store'), which will Router will use to create a fully qualified domain name (FQDN) e.g. `content-store.integration.govuk-internal.digital`.

This enables Router instances to determine the FQDN for a backend depending on its environment variables, rather than this being stored in the DB.

## Meta

https://trello.com/c/qtAZfkjg/403-work-out-whether-we-can-make-router-work-with-multiple-domains-and-a-single-database
