### PR TITLE
Specify empty Router URL list if none provided

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -6,7 +6,6 @@ ENV GOVUK_APP_NAME router-api
 ENV MONGODB_URI mongodb://mongo/router
 ENV PORT 3056
 ENV RAILS_ENV development
-ENV ROUTER_NODES router:3055
 ENV TEST_MONGODB_URI mongodb://mongo/router-test
 
 # place the AWS RDS Certificate Authority bundle at well known path

--- a/lib/router_reloader.rb
+++ b/lib/router_reloader.rb
@@ -14,7 +14,7 @@ class RouterReloader
       elsif !Rails.env.production?
         ["http://localhost:3055/reload"]
       else
-        raise "No router nodes provided. Need to set the ROUTER_NODES env variable"
+        []
       end
     end
   end


### PR DESCRIPTION
This PR changes the behaviour of the `urls` method to use an empty list if no router node endpoints can be found from either `ROUTER_NODES` or `ROUTER_NODES_FILE`. This change is part of the work to have Router update itself and no longer rely on Router API to manually call Routers' `/reload` endpoints.