### PR TITLE
Add RFC 141 healthcheck endpoints

### DIFF
--- a/config/routes.rb
+++ b/config/routes.rb
@@ -8,5 +8,10 @@ Rails.application.routes.draw do
     r.post "/routes/commit" => "routes#commit"
 
     r.get "/healthcheck" => proc { [200, {}, %w[OK]] }
+
+    r.get "/healthcheck/live", to: proc { [200, {}, %w[OK]] }
+    r.get "/healthcheck/ready", to: GovukHealthcheck.rack_response(
+      GovukHealthcheck::Mongoid,
+    )
   end
 end


### PR DESCRIPTION
I've added another check to this because it uses mongodb.

Once govuk-puppet has been updated, the old endpoint can be removed.

See the RFC for more details.

---

[Trello card](https://trello.com/c/tl6RV1el/723-improve-govuk-healthchecks)