### PR TITLE
Remove legacy /healthcheck route

### DIFF
--- a/config/routes.rb
+++ b/config/routes.rb
@@ -7,8 +7,6 @@ Rails.application.routes.draw do
     r.delete "/routes" => "routes#destroy"
     r.post "/routes/commit" => "routes#commit"
 
-    r.get "/healthcheck" => proc { [200, {}, %w[OK]] }
-
     r.get "/healthcheck/live", to: proc { [200, {}, %w[OK]] }
     r.get "/healthcheck/ready", to: GovukHealthcheck.rack_response(
       GovukHealthcheck::Mongoid,

--- a/spec/requests/healthcheck_spec.rb
+++ b/spec/requests/healthcheck_spec.rb
@@ -1,8 +1,0 @@
-require "rails_helper"
-
-RSpec.describe "Healthecheck", type: :request do
-  it "should resposnd on a healthcheck path" do
-    get "/healthcheck"
-    expect(response).to be_successful
-  end
-end


### PR DESCRIPTION
govuk-puppet and govuk-aws have now been updated to only use the new
routes, so the old one is no longer needed.

See RFC 141 for more information.

---

[Trello card](https://trello.com/c/tl6RV1el/723-improve-govuk-healthchecks)
