### PR TITLE
Bump i18n

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -124,7 +124,7 @@ GEM
       unicorn (>= 5.4, < 5.9)
     hashdiff (1.0.1)
     hashie (4.1.0)
-    i18n (1.9.0)
+    i18n (1.9.1)
       concurrent-ruby (~> 1.0)
     jwt (2.2.3)
     kgio (2.11.4)


### PR DESCRIPTION
i18n version 1.9.0 has been yanked due to a bug so we need to bump to
1.9.1.