### PR TITLE
Improve Dockerfile of router-api

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,3 +1,8 @@
 .git
 .gitignore
+Jenkinsfile
 README.md
+docs
+log
+spec
+tmp

--- a/config/puma.rb
+++ b/config/puma.rb
@@ -1,0 +1,2 @@
+require "govuk_app_config/govuk_puma"
+GovukPuma.configure_rails(self)


### PR DESCRIPTION
Improves the Dockerfile of router-api by using
mult-stage builds, using puma as web server and
removing some baked-in env vars.

Ref:
1. [trello card](https://trello.com/c/UHJvZubq/828-package-router-api-for-migration)