### PR TITLE
Fix race condition code failing to retry

### DIFF
--- a/app/controllers/routes_controller.rb
+++ b/app/controllers/routes_controller.rb
@@ -17,12 +17,8 @@ class RoutesController < ApplicationController
       @route = Route.find_or_initialize_by(incoming_path: incoming_path)
       status_code = @route.new_record? ? 201 : 200
       @route.update(route_details) || status_code = 422
-    rescue Mongo::Error::OperationFailure => e
-      if e.message.start_with?(Route::DUPLICATE_KEY_ERROR) && (tries -= 1).positive?
-        retry
-      else
-        raise
-      end
+    rescue Mongo::Error::OperationFailure
+      (tries -= 1).positive? ? retry : raise
     end
     render json: @route, status: status_code
   end

--- a/app/models/route.rb
+++ b/app/models/route.rb
@@ -19,8 +19,6 @@ class Route
 
   HANDLERS = %w[backend redirect gone].freeze
 
-  DUPLICATE_KEY_ERROR = "E11000".freeze
-
   validates :incoming_path, uniqueness: true
   validate :validate_incoming_path
   validates :route_type, inclusion: { in: %w[prefix exact] }


### PR DESCRIPTION
Trello: https://trello.com/c/CXTgjI76/383-look-at-sidekiqjobretryskip-errors-logged-to-sentry

Router API is vulnerable to a race condition when two requests arrive at
the same time, this is difficult to test and the previous work on this
test was to simplify it [1].

Unfortunately that simplification seems to have drifted out of sync with
how Mongoid operates and thus the test was passing without the behaviour
occurring as intended.

The problem is that the error message from MongoDB has now changed (it
is no longer prefixed with E11000 and instead: "[11000]: E11000
duplicate key...", which meant there were no retries occurring and
instead 500 errors raised.

To resolve the issue I decided to stop checking the error message, I
figure if we've just caught an Mongo::Error::OperationFailure, what's
the harm in retrying that even if it's not the key error? This makes the
code simpler.

For testing I went a bit more contrived to actually recreate the
exception Mongoid faces. This felt more reliable to me than
approximating it, since it's defined in an underlying library and
doesn't seem the most stable of exceptions [2].

[1]: https://github.com/alphagov/router-api/commit/834ae29dd8aa2170746a6db00e7dc01f7c37ff2f
[2]: https://github.com/alphagov/router-api/commit/db5063d529dbae60ebcc50ef7ae9965ebe77f23a