### PR TITLE
Enable CI in GitHub Actions

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -1,14 +1,14 @@
 name: CI
 
- on:
-   push:
-     branches:
-       - main
-   pull_request:
+on:
+  push:
+    branches:
+      - main
+  pull_request:
 
- jobs:
-   test:
-     name: Test Rails
-     uses: alphagov/govuk-infrastructure/.github/workflows/test-rails.yaml@main
-     with:
-       requiresMongoDB: true
+jobs:
+  test:
+    name: Test Rails
+    uses: alphagov/govuk-infrastructure/.github/workflows/test-rails.yaml@main
+    with:
+      requiresMongoDB: true

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -1,0 +1,14 @@
+name: CI
+
+ on:
+   push:
+     branches:
+       - main
+   pull_request:
+
+ jobs:
+   test:
+     name: Test Rails
+     uses: alphagov/govuk-infrastructure/.github/workflows/test-rails.yaml@main
+     with:
+       requiresMongoDB: true

--- a/.github/workflows/deploy.yaml
+++ b/.github/workflows/deploy.yaml
@@ -17,19 +17,18 @@ on:
         - staging
         - production
         default: 'integration'
-  push:
-    branches:
-      - main
-    paths-ignore:
-      - "Jenkinsfile"
-      - ".git**"
+  workflow_run:
+    workflows: [CI]
+    types: [completed]
+    branches: [main]
 
 jobs:
   build-and-publish-image:
     name: Build and publish image
+    if: github.event_name == 'workflow_dispatch' || github.event.workflow_run.conclusion == 'success'
     uses: alphagov/govuk-infrastructure/.github/workflows/ci-ecr.yaml@main
     with:
-      gitRef: ${{ github.event.inputs.gitRef }}
+      gitRef: ${{ github.event.inputs.gitRef || github.ref }}
     secrets:
       AWS_GOVUK_ECR_ACCESS_KEY_ID: ${{ secrets.AWS_GOVUK_ECR_ACCESS_KEY_ID }}
       AWS_GOVUK_ECR_SECRET_ACCESS_KEY: ${{ secrets.AWS_GOVUK_ECR_SECRET_ACCESS_KEY }}
@@ -39,7 +38,6 @@ jobs:
     uses: alphagov/govuk-infrastructure/.github/workflows/deploy.yaml@main
     with:
       imageTag: ${{ needs.build-and-publish-image.outputs.imageTag }}
-      workflowTrigger: ${{ github.event_name }}
       environment: ${{ github.event.inputs.environment }}
     secrets:
       WEBHOOK_TOKEN: ${{ secrets.GOVUK_INTEGRATION_ARGO_EVENTS_WEBHOOK_TOKEN }}

--- a/Gemfile
+++ b/Gemfile
@@ -10,6 +10,7 @@ gem "mongo", "~> 2.15.1"
 gem "mongoid"
 
 group :development, :test do
+  gem "brakeman"
   gem "byebug"
   gem "ci_reporter_rspec"
   gem "climate_control"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -69,6 +69,7 @@ GEM
     addressable (2.8.0)
       public_suffix (>= 2.0.2, < 5.0)
     ast (2.4.2)
+    brakeman (5.2.3)
     bson (4.15.0)
     builder (3.2.4)
     byebug (11.1.3)
@@ -322,6 +323,7 @@ PLATFORMS
   ruby
 
 DEPENDENCIES
+  brakeman
   byebug
   ci_reporter_rspec
   climate_control


### PR DESCRIPTION
This enables a GitHub Action workflow to run CI using a re-usableworkflow template in govuk-infrastructure repo. This is the initial set up to test the reusable workflow.

This PR also prevents the deploy workflow from being run before the application tests have been completed. This is to ensure that the commit passes application tests before being deployed.