### PR TITLE
Fix bug rejecting pathless redirect desinations

### DIFF
--- a/app/models/route.rb
+++ b/app/models/route.rb
@@ -103,7 +103,7 @@ private
     return if redirect_to.blank? # This is to short circuit nil values
 
     uri = URI.parse(redirect_to)
-    internal_uri = redirect_to.starts_with?(uri.path)
+    internal_uri = uri.path.present? && redirect_to.starts_with?(uri.path)
 
     if internal_uri
       errors.add(:redirect_to, "must start with a /") unless uri.path.starts_with?("/")

--- a/spec/models/route_spec.rb
+++ b/spec/models/route_spec.rb
@@ -204,6 +204,11 @@ RSpec.describe Route, type: :model do
           expect(route).to be_valid
         end
 
+        it "accepts an absolute URL" do
+          route.redirect_to = "https://www.oisc.gov.uk"
+          expect(route).to be_valid
+        end
+
         it "rejects an invalid URI" do
           route.redirect_to = "invalid url"
           expect(route).to be_invalid


### PR DESCRIPTION
This fixes an issue where redirect_to values were rejected if they were absolute URIs without a path. The reason they were failing is they were flagged as an internal URI, this occurred because they queried `redirect_to.starts_with?("")` which returned true as any string can start with an empty string.