### PR TITLE
Make redirect_to accept absolute URL without a path

### DIFF
--- a/app/models/route.rb
+++ b/app/models/route.rb
@@ -103,7 +103,7 @@ private
     return if redirect_to.blank? # This is to short circuit nil values
 
     uri = URI.parse(redirect_to)
-    internal_uri = redirect_to.starts_with?(uri.path)
+    internal_uri = uri.path.present? && redirect_to.starts_with?(uri.path)
 
     if internal_uri
       errors.add(:redirect_to, "must start with a /") unless uri.path.starts_with?("/")

--- a/spec/models/route_spec.rb
+++ b/spec/models/route_spec.rb
@@ -204,6 +204,11 @@ RSpec.describe Route, type: :model do
           expect(route).to be_valid
         end
 
+        it "accepts an absolute URL without a path" do
+          route.redirect_to = "https://www.oisc.gov.uk"
+          expect(route).to be_valid
+        end
+
         it "rejects an invalid URI" do
           route.redirect_to = "invalid url"
           expect(route).to be_invalid


### PR DESCRIPTION
The validation was treating external URIs without a path as internal because .starts_with?("") always returns true. As a result "https://www.oisc.gov.uk" raised "must start with a /“.

More granular validations are defined in the Publishing apps.

Zendesk: https://govuk.zendesk.com/agent/tickets/5108229