### PR TITLE
Hold back bad version 2.8.0 of the `mail` rubygem.

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -4,6 +4,7 @@ gem "rails", "7.0.4"
 
 gem "gds-sso"
 gem "govuk_app_config"
+gem "mail", "~> 2.7.1"  # TODO: remove once https://github.com/mikel/mail/issues/1489 is fixed.
 gem "plek"
 
 gem "mongo", "~> 2.15.1"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -323,6 +323,7 @@ DEPENDENCIES
   factory_bot_rails
   gds-sso
   govuk_app_config
+  mail (~> 2.7.1)
   mongo (~> 2.15.1)
   mongoid
   plek


### PR DESCRIPTION
Version 2.8.0 of the `mail` gem has the wrong filesystem permissions on a few of its .rb files (seems to be the generated tables?), which breaks the app when running as an unprivileged user. We therefore need to hold back this version of the gem until a new version is released that fixes the issue.

The upstream bug is mikel/mail#1489. We can remove this workaround once the bug is fixed.
