### PR TITLE
Remove workaround for bad `mail` gem release.

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -5,7 +5,6 @@ gem "rails", "7.0.4"
 gem "bootsnap", require: false
 gem "gds-sso"
 gem "govuk_app_config"
-gem "mail", "~> 2.7.1"  # TODO: remove once https://github.com/mikel/mail/issues/1489 is fixed.
 gem "plek"
 
 gem "mongo", "~> 2.15.1"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -89,6 +89,7 @@ GEM
     database_cleaner-mongoid (2.0.1)
       database_cleaner-core (~> 2.0.0)
       mongoid
+    date (3.3.3)
     diff-lcs (1.5.0)
     docile (1.4.0)
     erubi (1.12.0)
@@ -134,8 +135,11 @@ GEM
     loofah (2.19.1)
       crass (~> 1.0.2)
       nokogiri (>= 1.5.9)
-    mail (2.7.1)
+    mail (2.8.0.1)
       mini_mime (>= 0.1.1)
+      net-imap
+      net-pop
+      net-smtp
     marcel (1.0.2)
     method_source (1.0.0)
     mini_mime (1.1.2)
@@ -149,11 +153,12 @@ GEM
       ruby2_keywords (~> 0.0.5)
     msgpack (1.6.0)
     multi_xml (0.6.0)
-    net-imap (0.3.1)
+    net-imap (0.3.4)
+      date
       net-protocol
     net-pop (0.1.2)
       net-protocol
-    net-protocol (0.1.3)
+    net-protocol (0.2.1)
       timeout
     net-smtp (0.3.3)
       net-protocol
@@ -292,7 +297,7 @@ GEM
       version_gem (~> 1.1, >= 1.1.1)
     statsd-ruby (1.5.0)
     thor (1.2.1)
-    timeout (0.3.0)
+    timeout (0.3.1)
     tzinfo (2.0.5)
       concurrent-ruby (~> 1.0)
     unicode-display_width (2.3.0)
@@ -327,7 +332,6 @@ DEPENDENCIES
   factory_bot_rails
   gds-sso
   govuk_app_config
-  mail (~> 2.7.1)
   mongo (~> 2.15.1)
   mongoid
   plek


### PR DESCRIPTION
Remove the version constraint that we were using to avoid the bad release of the `mail` gem, now that https://www.github.com/mikel/mail/issues/1489 is fixed.

Update to `2.8.0.1`, which fixes the permissions issue.

Generated with `gsed -i '/gem "mail"/d' && bundle update mail`.
