### PR TITLE
Remove temporary rake task

### DIFF
--- a/lib/tasks/routes.rake
+++ b/lib/tasks/routes.rake
@@ -7,9 +7,4 @@ namespace :routes do
 
     RouteDumper.new(args[:filename]).dump
   end
-
-  desc "TEMP - Remove Whitehall Frontend routes"
-  task remove_whitehall_frontend_routes: :environment do
-    Route.where(handler: "backend", backend_id: "whitehall-frontend").delete_all
-  end
 end


### PR DESCRIPTION
it was there to remove some routes, they're gone now so we don't need the task