### PR TITLE
Fix wrong key name in Dependabot config.

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -4,7 +4,7 @@ updates:
     directory: /
     schedule:
       interval: daily
-    updateGroups:
+    groups:
       ruby-deps:
         patterns: ["*"]
   - package-ecosystem: docker
@@ -13,13 +13,13 @@ updates:
       interval: weekly
     ignore:
       - dependency-name: ruby
-    updateGroups:
+    groups:
       dockerfile-deps:
         patterns: ["*"]
   - package-ecosystem: github-actions
     directory: /
     schedule:
       interval: weekly
-    updateGroups:
+    groups:
       workflow-deps:
         patterns: ["*"]


### PR DESCRIPTION
Whoops. Fixes my mistake in #590.

GitHub are (still) working on [a pre-merge check](https://www.github.com/dependabot/dependabot-core/issues/4605) to catch this sort of thing 🤷 