### PR TITLE
Add appropriate version constraint for mongoid.

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -7,7 +7,7 @@ gem "gds-sso"
 gem "govuk_app_config"
 
 gem "mongo", "~> 2.15.1"
-gem "mongoid"
+gem "mongoid", "~> 7.5"
 
 group :development, :test do
   gem "brakeman"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -538,7 +538,7 @@ DEPENDENCIES
   gds-sso
   govuk_app_config
   mongo (~> 2.15.1)
-  mongoid
+  mongoid (~> 7.5)
   rack-handlers
   rails (= 7.0.8)
   rspec-rails


### PR DESCRIPTION
`mongoid` 7 is the last major version that's [compatible](https://www.mongodb.com/docs/mongoid/current/reference/compatibility/) with `mongo` driver 2.15 (which is the last version that's compatible with MongoDB 2, which we're stuck with for at least a few more weeks).

Hoping this also fixes the unexpected Dependabot behaviour in #592 where it tries to downgrade `mongoid` all the way to version 1.