### PR TITLE
Stop grouping Rubygems updates + switch to weekly.

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -3,10 +3,7 @@ updates:
   - package-ecosystem: bundler
     directory: /
     schedule:
-      interval: daily
-    groups:
-      ruby-deps:
-        patterns: ["*"]
+      interval: weekly
   - package-ecosystem: docker
     directory: /
     schedule:


### PR DESCRIPTION
Dependabot grouped updates are still not ready for prime time, not least cos `ignore <foo> minor version` and friends don't work.

Switch back to individual updates but reduce the frequency to weekly to keep a lid on the toil for now. We're an internal API so weekly is fine.

Might still switch this to Renovate if I have a spare few mins.