### PR TITLE
Make Dependabot ignore pinned dependencies

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -4,6 +4,9 @@ updates:
     directory: /
     schedule:
       interval: weekly
+    ignore:
+      - dependency-name: mongo
+      - dependency-name: mongoid
   - package-ecosystem: docker
     directory: /
     schedule:


### PR DESCRIPTION
It's trying to bump our manual constraints: https://github.com/alphagov/router-api/pull/625