### PR TITLE
Remove ability to disable routes

### DIFF
--- a/app/models/route.rb
+++ b/app/models/route.rb
@@ -5,7 +5,6 @@ class Route
   field :incoming_path, type: String
   field :route_type, type: String
   field :handler, type: String
-  field :disabled, type: Boolean, default: false
   field :backend_id, type: String
   field :redirect_to, type: String
   field :redirect_type, type: String

--- a/lib/route_dumper.rb
+++ b/lib/route_dumper.rb
@@ -2,7 +2,7 @@ require "csv"
 require "zlib"
 
 class RouteDumper
-  FIELDS = %w[incoming_path handler backend_id disabled redirect_to].freeze
+  FIELDS = %w[incoming_path handler backend_id redirect_to].freeze
 
   def initialize(filename)
     @filename = filename

--- a/spec/requests/routes_crud_spec.rb
+++ b/spec/requests/routes_crud_spec.rb
@@ -27,7 +27,6 @@ RSpec.describe "managing routes", type: :request do
         "route_type" => "exact",
         "handler" => "backend",
         "backend_id" => "a-backend",
-        "disabled" => false,
       )
     end
 
@@ -51,14 +50,12 @@ RSpec.describe "managing routes", type: :request do
         "route_type" => "prefix",
         "handler" => "backend",
         "backend_id" => "a-backend",
-        "disabled" => false,
       )
 
       route = Route.backend.where(incoming_path: "/foo/bar").first
       expect(route).to be
       expect(route.route_type).to eq("prefix")
       expect(route.backend_id).to eq("a-backend")
-      expect(route.disabled).to eq(false)
     end
 
     it "should return an error if given invalid data" do
@@ -70,7 +67,6 @@ RSpec.describe "managing routes", type: :request do
         "route_type" => "prefix",
         "handler" => "backend",
         "backend_id" => "",
-        "disabled" => false,
         "errors" => {
           "backend_id" => ["can't be blank"],
         },
@@ -97,7 +93,6 @@ RSpec.describe "managing routes", type: :request do
         "route_type" => "exact",
         "handler" => "backend",
         "backend_id" => "another-backend",
-        "disabled" => false,
       )
 
       route = Route.backend.where(incoming_path: "/foo/bar").first
@@ -115,7 +110,6 @@ RSpec.describe "managing routes", type: :request do
         "route_type" => "prefix",
         "handler" => "backend",
         "backend_id" => "",
-        "disabled" => false,
         "errors" => {
           "backend_id" => ["can't be blank"],
         },
@@ -124,42 +118,6 @@ RSpec.describe "managing routes", type: :request do
       route = Route.where(incoming_path: "/foo/bar").first
       expect(route).to be
       expect(route.backend_id).to eq("a-backend")
-    end
-
-    describe "updating the disabled flag" do
-      it "should set the disabled flag to the value given in the request" do
-        put_json "/routes", route: { incoming_path: "/foo/bar", disabled: true }
-
-        expect(response.code.to_i).to eq(200)
-        expect(JSON.parse(response.body)).to include("disabled" => true)
-
-        route = Route.where(incoming_path: "/foo/bar").first
-        expect(route.disabled).to eq(true)
-      end
-
-      it "should not change the disabled flag when not specified in the request" do
-        @route.update!(disabled: true)
-
-        put_json "/routes", route: { incoming_path: "/foo/bar", route_type: "exact", handler: "backend", backend_id: "another-backend" }
-
-        expect(response.code.to_i).to eq(200)
-        route = Route.where(incoming_path: "/foo/bar").first
-        expect(route.backend_id).to eq("another-backend")
-
-        expect(route.disabled).to eq(true)
-      end
-
-      it "should not alter other details of the route when only setting the flag" do
-        put_json "/routes", route: { incoming_path: "/foo/bar", disabled: true }
-
-        expect(response.code.to_i).to eq(200)
-        expect(JSON.parse(response.body)).to include("disabled" => true)
-
-        route = Route.where(incoming_path: "/foo/bar").first
-        expect(route.route_type).to eq("prefix")
-        expect(route.handler).to eq("backend")
-        expect(route.backend_id).to eq("a-backend")
-      end
     end
 
     it "should not blow up if not given the necessary route lookup keys" do
@@ -191,7 +149,6 @@ RSpec.describe "managing routes", type: :request do
         "route_type" => "exact",
         "handler" => "backend",
         "backend_id" => "a-backend",
-        "disabled" => false,
       )
 
       route = Route.where(incoming_path: "/foo/bar").first


### PR DESCRIPTION
This was [introduced 9 years ago](https://github.com/alphagov/router/pull/100) as a way to take a service offline for maintenance.

This functionality is no longer needed or supported via the GDS API adapters/used when publishing routes.

Associated PR for router:
https://github.com/alphagov/router/pull/481