### PR TITLE
Unset the backend_id for redirects and gone routes

### DIFF
--- a/app/models/route.rb
+++ b/app/models/route.rb
@@ -36,6 +36,7 @@ class Route
   end
 
   before_validation :default_segments_mode
+  before_save :remove_backend_id_for_non_backend_routes
   after_create :cleanup_child_gone_routes
 
   scope :excluding, ->(route) { where(id: { :$ne => route.id }) }
@@ -130,6 +131,10 @@ private
     unless Backend.where(backend_id:).exists?
       errors.add(:backend_id, "does not exist")
     end
+  end
+
+  def remove_backend_id_for_non_backend_routes
+    self.backend_id = nil unless backend?
   end
 
   def cleanup_child_gone_routes

--- a/spec/models/route_spec.rb
+++ b/spec/models/route_spec.rb
@@ -215,6 +215,12 @@ RSpec.describe Route, type: :model do
         end
       end
 
+      describe "backend_id" do
+        it "is set to nil" do
+          expect(route.backend_id).to be nil
+        end
+      end
+
       context "and segments_mode set to 'ignore'" do
         subject(:route) { FactoryBot.build(:redirect_route, segments_mode: "ignore") }
 
@@ -246,6 +252,20 @@ RSpec.describe Route, type: :model do
           end
         end
       end
+    end
+  end
+
+  describe "changing backend route to redirect route" do
+    it "will clear the backend_id" do
+      route = FactoryBot.create(:backend_route)
+      route.update!(
+        handler: "redirect",
+        redirect_to: "/",
+        redirect_type: "permanent",
+      )
+      route.reload
+
+      expect(route.backend_id).to be nil
     end
   end
 


### PR DESCRIPTION
Backends should only be set for routes with the "backend" handler. Redirects and gone routes are handled directly in router and are not proxied. This creates confusion in the data model, as redirect can currently have a backend (however, its not sent to the backend).