### PR TITLE
Remove support for temporary redirects

### DIFF
--- a/app/controllers/routes_controller.rb
+++ b/app/controllers/routes_controller.rb
@@ -10,6 +10,8 @@ class RoutesController < ApplicationController
   def update
     route_details = @request_data[:route]
     incoming_path = route_details.delete(:incoming_path)
+    # TODO: remove this once gds-api-adapters no longer send this attribute
+    route_details.delete("redirect_type")
     tries = 3
     begin
       @route = Route.find_or_initialize_by(incoming_path:)

--- a/app/models/route.rb
+++ b/app/models/route.rb
@@ -7,7 +7,6 @@ class Route
   field :handler, type: String
   field :backend_id, type: String
   field :redirect_to, type: String
-  field :redirect_type, type: String
   field :segments_mode, type: String
 
   index({ incoming_path: 1 }, unique: true)
@@ -30,7 +29,6 @@ class Route
   with_options if: :redirect? do
     validates :redirect_to, presence: true
     validate :validate_redirect_to
-    validates :redirect_type, inclusion: { in: %w[permanent temporary] }
     validates :segments_mode, inclusion: { in: %w[ignore preserve] }
   end
 
@@ -61,7 +59,7 @@ class Route
     if has_parent_prefix_routes?
       destroy!
     else
-      update!(handler: "gone", backend_id: nil, redirect_to: nil, redirect_type: nil)
+      update!(handler: "gone", backend_id: nil, redirect_to: nil)
     end
   end
 

--- a/lib/tasks/redirect.rake
+++ b/lib/tasks/redirect.rake
@@ -12,7 +12,6 @@ def redirect(old_path, new_path)
     route_type: "exact",
     handler: "redirect",
     backend_id: "whitehall-frontend",
-    redirect_type: "permanent",
     segments_mode: "ignore",
   )
 end

--- a/spec/factories/routes.rb
+++ b/spec/factories/routes.rb
@@ -14,7 +14,6 @@ FactoryBot.define do
     factory :redirect_route do
       handler { "redirect" }
       redirect_to { "/bar" }
-      redirect_type { "permanent" }
     end
 
     factory :gone_route do

--- a/spec/models/route_spec.rb
+++ b/spec/models/route_spec.rb
@@ -261,7 +261,6 @@ RSpec.describe Route, type: :model do
       route.update!(
         handler: "redirect",
         redirect_to: "/",
-        redirect_type: "permanent",
       )
       route.reload
 


### PR DESCRIPTION
These redirects are 302 Found responses, however no longer used. Removing to simplify the codebase.

https://github.com/alphagov/router/pull/482